### PR TITLE
feat: cursor providers

### DIFF
--- a/.github/workflows/branch-test.yml
+++ b/.github/workflows/branch-test.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build
         run: make build-dev
 
+      - name: Lint
+        run: make lint
+
       - name: Unit Tests
         run: make test-unit
 

--- a/.github/workflows/branch-test.yml
+++ b/.github/workflows/branch-test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set Rust version
-        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy
 
       - name: Build
         run: make build-dev

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 build-dev:
 	cargo build --verbose
 
+# Run clippy to lint the project:
+lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+
 # Run all the unit tests
 test-unit:
 	cargo test --lib --profile test --verbose

--- a/juniper_relay_helpers/src/connections.rs
+++ b/juniper_relay_helpers/src/connections.rs
@@ -12,7 +12,7 @@ pub trait RelayConnection {
     /// Builds a connection and associated edges from a Vec of the Nodes themselves. Pagination cursors
     /// can also be generated for you by providing the page info and CursorProvider trait instance.
     fn new(
-        nodes: &Vec<Self::NodeType>,
+        nodes: &[Self::NodeType],
         total_items: i32,
         cursor_provider: impl CursorProvider,
         page_request: Option<crate::PageRequest>
@@ -46,18 +46,6 @@ mod tests {
         assert_eq!(conn.count, 12);
         assert_eq!(conn.edges.len(), 0);
     }
-
-    // #[test]
-    // fn connection_new_generated() {
-    //     let conn = UserRelayConnection::new(
-    //         vec![
-    //             User { name: "Lune".to_owned() },
-    //         ],
-    //         127,
-    //         todo!(),
-    //         None
-    //     );
-    // }
 
     #[test]
     fn edge_types_are_generated() {

--- a/juniper_relay_helpers/src/connections.rs
+++ b/juniper_relay_helpers/src/connections.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod tests {
     use juniper::GraphQLObject;
-    use juniper_relay_helpers_codegen::RelayConnection;
-    use crate::PageInfo;
+    use juniper_relay_helpers_codegen::{RelayConnection};
+    use crate::{OffsetCursor, PageInfo, RelayEdge};
 
     #[derive(Debug, RelayConnection, GraphQLObject, Clone, Eq, PartialEq)]
-    struct User {
+    pub struct User {
         name: String,
     }
 
@@ -36,5 +36,20 @@ mod tests {
         };
         assert_eq!(edge.node.name, "Lune");
         assert_eq!(edge.cursor, Some("some-string".to_owned()));
+    }
+
+    #[test]
+    fn edge_implementation_new() {
+        let edge = UserRelayEdge::new(User {
+            name: "Lune".to_owned(),
+        }, OffsetCursor { offset: 0, first: 10 });
+        assert_eq!(edge.node.name, "Lune");
+        assert_eq!(edge.cursor, Some("b2Zmc2V0OjA6MTA=".into()));
+
+        let edge2 = UserRelayEdge::new_raw_cursor(User {
+            name: "Sciel".to_owned(),
+        }, Some("some-cursor".to_owned()));
+        assert_eq!(edge2.node.name, "Sciel");
+        assert_eq!(edge2.cursor, Some("some-cursor".into()));
     }
 }

--- a/juniper_relay_helpers/src/connections.rs
+++ b/juniper_relay_helpers/src/connections.rs
@@ -1,10 +1,31 @@
+use crate::cursor_provider::{CursorProvider};
+use crate::{RelayEdge};
+
+/// Common trait for Relay connections. Will be implemented by the codegen.
+pub trait RelayConnection {
+    /// The type of the Edge - this will be added for you in the codegen.
+    type EdgeType: RelayEdge;
+
+    /// The underlying type of Node we're Connection-ing. Will be filled in for you by the codegen.
+    type NodeType;
+
+    /// Builds a connection and associated edges from a Vec of the Nodes themselves. Pagination cursors
+    /// can also be generated for you by providing the page info and CursorProvider trait instance.
+    fn new(
+        nodes: &Vec<Self::NodeType>,
+        total_items: i32,
+        cursor_provider: impl CursorProvider,
+        page_request: Option<crate::PageRequest>
+    ) -> Self;
+}
+
 #[cfg(test)]
 mod tests {
     use juniper::GraphQLObject;
     use juniper_relay_helpers_codegen::{RelayConnection};
-    use crate::{OffsetCursor, PageInfo, RelayEdge};
+    use crate::{OffsetCursor, PageInfo, RelayConnection as RelayConnectionTrait};
 
-    #[derive(Debug, RelayConnection, GraphQLObject, Clone, Eq, PartialEq)]
+    #[derive(Debug, GraphQLObject, RelayConnection, Clone, Eq, PartialEq)]
     pub struct User {
         name: String,
     }
@@ -26,6 +47,18 @@ mod tests {
         assert_eq!(conn.edges.len(), 0);
     }
 
+    // #[test]
+    // fn connection_new_generated() {
+    //     let conn = UserRelayConnection::new(
+    //         vec![
+    //             User { name: "Lune".to_owned() },
+    //         ],
+    //         127,
+    //         todo!(),
+    //         None
+    //     );
+    // }
+
     #[test]
     fn edge_types_are_generated() {
         let edge = UserRelayEdge {
@@ -42,7 +75,7 @@ mod tests {
     fn edge_implementation_new() {
         let edge = UserRelayEdge::new(User {
             name: "Lune".to_owned(),
-        }, OffsetCursor { offset: 0, first: 10 });
+        }, OffsetCursor { offset: 0, first: Some(10) });
         assert_eq!(edge.node.name, "Lune");
         assert_eq!(edge.cursor, Some("b2Zmc2V0OjA6MTA=".into()));
 

--- a/juniper_relay_helpers/src/connections.rs
+++ b/juniper_relay_helpers/src/connections.rs
@@ -23,7 +23,7 @@ pub trait RelayConnection {
 mod tests {
     use juniper::GraphQLObject;
     use juniper_relay_helpers_codegen::{RelayConnection};
-    use crate::{OffsetCursor, PageInfo, RelayConnection as RelayConnectionTrait};
+    use crate::{OffsetCursor, PageInfo};
 
     #[derive(Debug, GraphQLObject, RelayConnection, Clone, Eq, PartialEq)]
     pub struct User {

--- a/juniper_relay_helpers/src/cursor_errors.rs
+++ b/juniper_relay_helpers/src/cursor_errors.rs
@@ -2,7 +2,10 @@ use std::string::FromUtf8Error;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum CursorError {
+    /// Returned when the cursor is invalid - wrong number of segments, mismatch of types, etc.
     InvalidCursor,
+
+    /// Returned when the base64 encoding on the cursor is invalid.
     InvalidCursorEncoding,
 }
 

--- a/juniper_relay_helpers/src/cursor_provider.rs
+++ b/juniper_relay_helpers/src/cursor_provider.rs
@@ -83,7 +83,7 @@ impl CursorProvider for OffsetCursorProvider {
                 false
             }
         } else {
-            // We didn't request a first, which means entire result set, therefore no next page
+            // We didn't request a first, which means the entire result set, therefore no next page
             false
         };
 
@@ -244,27 +244,6 @@ mod tests {
             assert_eq!(pi3.start_cursor, Some(OffsetCursor { offset: 10, first: None }.to_encoded_string()));
             assert_eq!(pi3.end_cursor, Some(OffsetCursor { offset: 12, first: None }.to_encoded_string()));
         }
-
-       //  /// Mimics a subsequent page request - there's an `after` and a `first`
-         // /// TODO: I think this is actually an off-by-one error :yikes:
-        // #[test]
-        // fn test_page_info_has_request_subsequent_page() {
-        //     let p = OffsetCursorProvider::new();
-        //     let pi = p.get_page_info(&PaginationMetadata {
-        //         total_count: 27,
-        //         page_request: Some(
-        //             PageRequest {
-        //                 first: Some(10),
-        //                 after: Some(OffsetCursor { offset: 9, first: Some(10) }.to_encoded_string())
-        //             }
-        //         )
-        //     }, &data());
-        //
-        //     assert_eq!(pi.has_prev_page, true);
-        //     assert_eq!(pi.has_next_page, true);
-        //     assert_eq!(pi.start_cursor, Some(OffsetCursor { offset: 9, first: Some(10) }.to_encoded_string()));
-        //     assert_eq!(pi.end_cursor, Some(OffsetCursor { offset: 10, first: Some(10) }.to_encoded_string()));
-        // }
     }
 }
 

--- a/juniper_relay_helpers/src/cursor_provider.rs
+++ b/juniper_relay_helpers/src/cursor_provider.rs
@@ -40,17 +40,27 @@ pub trait CursorProvider {
 pub struct OffsetCursorProvider;
 impl CursorProvider for OffsetCursorProvider {
     fn get_cursor_for_item<T>(&self, metadata: &PaginationMetadata, item_idx: i32, _item: &T) -> impl Cursor {
+        // OK this is annoying. If there _was_ a cursor passed to `after`, the offset needs to start
+        // at the next item. If there wasn't, the offset needs to start at the first item (0).
+        let mut offset_adjust = 0;
+
         let default_cursor = OffsetCursor::default();
         let current_cursor = match &metadata.page_request {
             Some(pr) => match pr.parsed_cursor() {
-                Ok(c) => c.unwrap_or(default_cursor),
+                Ok(c) => match c {
+                    Some(cc) => {
+                        offset_adjust = 1;
+                        cc
+                    },
+                    None => default_cursor
+                },
                 Err(_) => default_cursor
             },
             None => default_cursor
         };
 
         OffsetCursor {
-            offset: current_cursor.offset + item_idx,
+            offset: current_cursor.offset + offset_adjust + item_idx,
             first: current_cursor.first
         }
     }
@@ -65,8 +75,17 @@ impl CursorProvider for OffsetCursorProvider {
             None => default_cursor
         };
 
-        let has_next_page = items.len() > 0
-            && (current_cursor.offset + items.len() as i32) < metadata.total_count;
+        let has_next_page = if let Some(pr) = &metadata.page_request {
+            // Check if we requested up to or over the total items.
+            if let Some(first) = pr.first {
+                current_cursor.offset + first < metadata.total_count
+            } else {
+                false
+            }
+        } else {
+            // We didn't request a first, which means entire result set, therefore no next page
+            false
+        };
 
         let last_index = items.len() - 1;
 
@@ -105,6 +124,7 @@ mod tests {
     mod offset_cursor_provider {
         use crate::{OffsetCursorProvider, PaginationMetadata, CursorProvider, Cursor, OffsetCursor, PageRequest};
 
+        #[derive(Debug, Clone)]
         struct Location {
             name: String
         }
@@ -133,7 +153,8 @@ mod tests {
         }
 
         /// Verifies what happens when there's a mismatch between the total count and the number of items
-        /// returned from the query. Should still say there's a next page as the result set may be short.
+        /// returned from the query. Due to the lack of PageRequest, should say no next page as all results
+        /// will have been returned.
         #[test]
         fn test_page_info_no_request_mismatch_results_count() {
             let p = OffsetCursorProvider::new();
@@ -143,7 +164,7 @@ mod tests {
             }, &data());
 
             assert_eq!(pi.has_prev_page, false);
-            assert_eq!(pi.has_next_page, true);
+            assert_eq!(pi.has_next_page, false);
             assert_eq!(pi.start_cursor, Some(OffsetCursor { offset: 0, first: None }.to_encoded_string()));
             assert_eq!(pi.end_cursor, Some(OffsetCursor { offset: 1, first: None }.to_encoded_string()));
         }
@@ -168,26 +189,82 @@ mod tests {
             assert_eq!(pi.end_cursor, Some(OffsetCursor { offset: 1, first: None }.to_encoded_string()));
         }
 
-        /// Mimics a subsequent page request - there's an `after` and a `first`
-        /// TODO: I think this is actually an off-by-one error :yikes:
+        /// Test mimics pagination through a full set of results
         #[test]
-        fn test_page_info_has_request_subsequent_page() {
+        fn test_page_info_paginating_through_set() {
             let p = OffsetCursorProvider::new();
-            let pi = p.get_page_info(&PaginationMetadata {
-                total_count: 27,
+            let total_items = 13;
+            let data = vec![
+                Location { name: "Lumiére".to_owned() },
+                Location { name: "Spring Meadows".to_owned() },
+                Location { name: "Flying Waters".to_owned() },
+                Location { name: "Gestral Village".to_owned() },
+                Location { name: "Stone Wave Cliffs".to_owned() }
+            ];
+
+            let pi1 = p.get_page_info(&PaginationMetadata {
+                total_count: total_items,
                 page_request: Some(
                     PageRequest {
-                        first: Some(10),
-                        after: Some(OffsetCursor { offset: 9, first: Some(10) }.to_encoded_string())
+                        first: Some(5),
+                        after: None
                     }
                 )
-            }, &data());
+            }, &data);
+            assert_eq!(pi1.has_prev_page, false);
+            assert_eq!(pi1.has_next_page, true);
+            assert_eq!(pi1.start_cursor, Some(OffsetCursor { offset: 0, first: None }.to_encoded_string()));
+            assert_eq!(pi1.end_cursor, Some(OffsetCursor { offset: 4, first: None }.to_encoded_string()));
 
-            assert_eq!(pi.has_prev_page, true);
-            assert_eq!(pi.has_next_page, true);
-            assert_eq!(pi.start_cursor, Some(OffsetCursor { offset: 9, first: Some(10) }.to_encoded_string()));
-            assert_eq!(pi.end_cursor, Some(OffsetCursor { offset: 10, first: Some(10) }.to_encoded_string()));
+            let pi2 = p.get_page_info(&PaginationMetadata {
+                total_count: total_items,
+                page_request: Some(
+                    PageRequest {
+                        first: Some(5),
+                        after: pi1.end_cursor.clone()
+                    }
+                )
+            }, &data);
+            assert_eq!(pi2.has_prev_page, true);
+            assert_eq!(pi2.has_next_page, true);
+            assert_eq!(pi2.start_cursor, Some(OffsetCursor { offset: 5, first: None }.to_encoded_string()));
+            assert_eq!(pi2.end_cursor, Some(OffsetCursor { offset: 9, first: None }.to_encoded_string()));
+
+            let pi3 = p.get_page_info(&PaginationMetadata {
+                total_count: total_items,
+                page_request: Some(
+                    PageRequest {
+                        first: Some(5),
+                        after: pi2.end_cursor.clone()
+                    }
+                )
+            }, &vec![data[0].clone(), data[1].clone(), data[2].clone()]);
+            assert_eq!(pi3.has_prev_page, true);
+            assert_eq!(pi3.has_next_page, false);
+            assert_eq!(pi3.start_cursor, Some(OffsetCursor { offset: 10, first: None }.to_encoded_string()));
+            assert_eq!(pi3.end_cursor, Some(OffsetCursor { offset: 12, first: None }.to_encoded_string()));
         }
+
+       //  /// Mimics a subsequent page request - there's an `after` and a `first`
+         // /// TODO: I think this is actually an off-by-one error :yikes:
+        // #[test]
+        // fn test_page_info_has_request_subsequent_page() {
+        //     let p = OffsetCursorProvider::new();
+        //     let pi = p.get_page_info(&PaginationMetadata {
+        //         total_count: 27,
+        //         page_request: Some(
+        //             PageRequest {
+        //                 first: Some(10),
+        //                 after: Some(OffsetCursor { offset: 9, first: Some(10) }.to_encoded_string())
+        //             }
+        //         )
+        //     }, &data());
+        //
+        //     assert_eq!(pi.has_prev_page, true);
+        //     assert_eq!(pi.has_next_page, true);
+        //     assert_eq!(pi.start_cursor, Some(OffsetCursor { offset: 9, first: Some(10) }.to_encoded_string()));
+        //     assert_eq!(pi.end_cursor, Some(OffsetCursor { offset: 10, first: Some(10) }.to_encoded_string()));
+        // }
     }
 }
 

--- a/juniper_relay_helpers/src/cursor_provider.rs
+++ b/juniper_relay_helpers/src/cursor_provider.rs
@@ -1,7 +1,193 @@
+use juniper_relay_helpers::{Cursor, OffsetCursor, PageInfo, PageRequest};
+
+/// Struct that holds metadata about the response that can be used in the CursorProvider
+#[derive(Debug, Clone)]
+pub struct PaginationMetadata {
+    /// The total number of items in the result set:
+    pub total_count: i32,
+
+    /// The current PageInfo, if any:
+    pub page_request: Option<PageRequest>,
+}
+
 /// Trait to implement when building a Relay cursor provider.
 ///
 /// Cursor providers are how we generate cursors for each of the individual items
 /// within the result set, without needing to do a pass and build them manually.
+///
 pub trait CursorProvider {
-    fn get_cursor(&self, ) -> String;
+    /// Build a cursor instance for the given item, with helper metadata etc.
+    ///
+    /// `metadata` is information about the current resultset we're building for.
+    /// `item_idx` is the index of the item we're building a cursor for.
+    /// `item` is the item itself.
+    fn get_cursor_for_item<T>(
+        &self,
+        metadata: &PaginationMetadata,
+        item_idx: i32,
+        item: &T
+    ) -> impl Cursor;
+
+    /// Builds the `PageInfo` to return to the RelayConnection
+    fn get_page_info<T>(&self, metadata: &PaginationMetadata, items: &Vec<T>) -> PageInfo;
 }
+
+
+// -------------- OffsetCursorProvider ---------------
+
+/// Built-in cursor provider that can handle Offset cursors. Serves as a reference implementation for
+/// your own cursor providers too.
+pub struct OffsetCursorProvider;
+impl CursorProvider for OffsetCursorProvider {
+    fn get_cursor_for_item<T>(&self, metadata: &PaginationMetadata, item_idx: i32, _item: &T) -> impl Cursor {
+        let default_cursor = OffsetCursor::default();
+        let current_cursor = match &metadata.page_request {
+            Some(pr) => match pr.parsed_cursor() {
+                Ok(c) => c.unwrap_or(default_cursor),
+                Err(_) => default_cursor
+            },
+            None => default_cursor
+        };
+
+        OffsetCursor {
+            offset: current_cursor.offset + item_idx,
+            first: current_cursor.first
+        }
+    }
+
+    fn get_page_info<T>(&self, metadata: &PaginationMetadata, items: &Vec<T>) -> PageInfo {
+        let default_cursor = OffsetCursor::default();
+        let current_cursor = match &metadata.page_request {
+            Some(pr) => match pr.parsed_cursor() {
+                Ok(c) => c.unwrap_or(default_cursor),
+                Err(_) => default_cursor
+            },
+            None => default_cursor
+        };
+
+        let has_next_page = items.len() > 0
+            && (current_cursor.offset + items.len() as i32) < metadata.total_count;
+
+        let last_index = items.len() - 1;
+
+        PageInfo {
+            has_prev_page: current_cursor.offset > 0,
+            has_next_page,
+            start_cursor: if items.len() > 0 {
+                Some(
+                    self.get_cursor_for_item(metadata, 0, &items[0])
+                        .to_encoded_string()
+                )
+            } else {
+                None
+            },
+            end_cursor: if items.len() > 0 {
+                Some(
+                    self.get_cursor_for_item(metadata, last_index as i32, &items[last_index])
+                        .to_encoded_string()
+                )
+            } else {
+                None
+            },
+        }
+    }
+}
+
+impl OffsetCursorProvider {
+    pub fn new() -> Self {
+        OffsetCursorProvider
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    mod offset_cursor_provider {
+        use crate::{OffsetCursorProvider, PaginationMetadata, CursorProvider, Cursor, OffsetCursor, PageRequest};
+
+        struct Location {
+            name: String
+        }
+
+        fn data() -> Vec<Location> {
+            vec![
+                Location { name: "Lumiére".to_owned() },
+                Location { name: "Flying Waters".to_owned() }
+            ]
+        }
+
+        /// Mimics a "complete" request - no `first` and no `after` with the total result set returned
+        /// as part of the payload.
+        #[test]
+        fn test_page_info_no_request() {
+            let p = OffsetCursorProvider::new();
+            let pi = p.get_page_info(&PaginationMetadata {
+                total_count: 2,
+                page_request: None
+            }, &data());
+
+            assert_eq!(pi.has_prev_page, false);
+            assert_eq!(pi.has_next_page, false);
+            assert_eq!(pi.start_cursor, Some(OffsetCursor { offset: 0, first: None }.to_encoded_string()));
+            assert_eq!(pi.end_cursor, Some(OffsetCursor { offset: 1, first: None }.to_encoded_string()));
+        }
+
+        /// Verifies what happens when there's a mismatch between the total count and the number of items
+        /// returned from the query. Should still say there's a next page as the result set may be short.
+        #[test]
+        fn test_page_info_no_request_mismatch_results_count() {
+            let p = OffsetCursorProvider::new();
+            let pi = p.get_page_info(&PaginationMetadata {
+                total_count: 27,
+                page_request: None
+            }, &data());
+
+            assert_eq!(pi.has_prev_page, false);
+            assert_eq!(pi.has_next_page, true);
+            assert_eq!(pi.start_cursor, Some(OffsetCursor { offset: 0, first: None }.to_encoded_string()));
+            assert_eq!(pi.end_cursor, Some(OffsetCursor { offset: 1, first: None }.to_encoded_string()));
+        }
+
+        /// Mimics a first page request - there's no `after` but there is a provided `first`
+        #[test]
+        fn test_page_info_has_request_first_page() {
+            let p = OffsetCursorProvider::new();
+            let pi = p.get_page_info(&PaginationMetadata {
+                total_count: 27,
+                page_request: Some(
+                    PageRequest {
+                        first: Some(10),
+                        after: None
+                    }
+                )
+            }, &data());
+
+            assert_eq!(pi.has_prev_page, false);
+            assert_eq!(pi.has_next_page, true);
+            assert_eq!(pi.start_cursor, Some(OffsetCursor { offset: 0, first: None }.to_encoded_string()));
+            assert_eq!(pi.end_cursor, Some(OffsetCursor { offset: 1, first: None }.to_encoded_string()));
+        }
+
+        /// Mimics a subsequent page request - there's an `after` and a `first`
+        /// TODO: I think this is actually an off-by-one error :yikes:
+        #[test]
+        fn test_page_info_has_request_subsequent_page() {
+            let p = OffsetCursorProvider::new();
+            let pi = p.get_page_info(&PaginationMetadata {
+                total_count: 27,
+                page_request: Some(
+                    PageRequest {
+                        first: Some(10),
+                        after: Some(OffsetCursor { offset: 9, first: Some(10) }.to_encoded_string())
+                    }
+                )
+            }, &data());
+
+            assert_eq!(pi.has_prev_page, true);
+            assert_eq!(pi.has_next_page, true);
+            assert_eq!(pi.start_cursor, Some(OffsetCursor { offset: 9, first: Some(10) }.to_encoded_string()));
+            assert_eq!(pi.end_cursor, Some(OffsetCursor { offset: 10, first: Some(10) }.to_encoded_string()));
+        }
+    }
+}
+

--- a/juniper_relay_helpers/src/cursor_provider.rs
+++ b/juniper_relay_helpers/src/cursor_provider.rs
@@ -113,6 +113,8 @@ impl CursorProvider for OffsetCursorProvider {
 }
 
 impl OffsetCursorProvider {
+    /// Shortcut method for creating a new instance of OffsetCursorProvider. May be used in the future
+    /// if we need to pass things into it.
     pub fn new() -> Self {
         OffsetCursorProvider
     }

--- a/juniper_relay_helpers/src/cursors.rs
+++ b/juniper_relay_helpers/src/cursors.rs
@@ -115,12 +115,22 @@ impl Cursor for OffsetCursor {
     }
 
     fn new(_raw: &str, parts: Vec<&str>) -> Result<OffsetCursor, CursorError> {
+        if parts.len() != 2 && parts.len() != 3 {
+            return Err(CursorError::InvalidCursor);
+        }
+
+        // Offset is always defined
         let offset = parts[1].parse::<i32>()
             .unwrap_or(0);
 
-        let first: Option<i32> = match parts[2].parse::<i32>() {
-            Ok(f) => Some(f),
-            Err(_) => None,
+        // First is optional and can be missing
+        let first: Option<i32> = if parts.len() == 2{
+            None
+        } else {
+            match parts[2].parse::<i32>() {
+                Ok(f) => Some(f),
+                Err(_) => None,
+            }
         };
 
         Ok(OffsetCursor { offset, first })

--- a/juniper_relay_helpers/src/cursors.rs
+++ b/juniper_relay_helpers/src/cursors.rs
@@ -154,7 +154,13 @@ impl Default for OffsetCursor {
 #[derive(Debug, GraphQLScalar)]
 pub struct StringCursor {
     /// The value of the cursor.
-    value: String,
+    pub value: String,
+}
+
+impl StringCursor {
+    pub fn new(value: String) -> Self {
+        StringCursor { value }
+    }
 }
 
 impl Cursor for StringCursor {

--- a/juniper_relay_helpers/src/cursors.rs
+++ b/juniper_relay_helpers/src/cursors.rs
@@ -95,6 +95,7 @@ pub fn cursor_from_encoded_string<T>(input: &str) -> Result<T, CursorError> wher
     to_output_with = Self::to_output,
     from_input_with = Self::from_input
 )]
+#[derive(Default)]
 pub struct OffsetCursor {
     /// The offset of the cursor (how many items to skip).
     pub offset: i32,
@@ -127,10 +128,7 @@ impl Cursor for OffsetCursor {
         let first: Option<i32> = if parts.len() == 2{
             None
         } else {
-            match parts[2].parse::<i32>() {
-                Ok(f) => Some(f),
-                Err(_) => None,
-            }
+            parts[2].parse::<i32>().ok()
         };
 
         Ok(OffsetCursor { offset, first })
@@ -143,11 +141,6 @@ impl Display for OffsetCursor {
     }
 }
 
-impl Default for OffsetCursor {
-    fn default() -> Self {
-        OffsetCursor { offset: 0, first: None }
-    }
-}
 
 /// Built-in cursor type for when the cursor is just a string. Usually useful for things like
 /// NoSQL systems that return something opaque to you.

--- a/juniper_relay_helpers/src/cursors.rs
+++ b/juniper_relay_helpers/src/cursors.rs
@@ -100,19 +100,29 @@ pub struct OffsetCursor {
     pub offset: i32,
 
     /// The number of items to return.
-    pub first: i32,
+    pub first: Option<i32>,
 }
 
 impl Cursor for OffsetCursor {
     type CursorType = OffsetCursor;
 
     fn to_raw_string(&self) -> String {
-        format!("offset:{}:{}", self.offset, self.first)
+        if let Some(first) = self.first {
+            format!("offset:{}:{}", self.offset, first)
+        } else {
+            format!("offset:{}", self.offset)
+        }
     }
 
     fn new(_raw: &str, parts: Vec<&str>) -> Result<OffsetCursor, CursorError> {
-        let offset = parts[1].parse::<i32>().unwrap_or(0);
-        let first = parts[2].parse::<i32>().unwrap_or(0);
+        let offset = parts[1].parse::<i32>()
+            .unwrap_or(0);
+
+        let first: Option<i32> = match parts[2].parse::<i32>() {
+            Ok(f) => Some(f),
+            Err(_) => None,
+        };
+
         Ok(OffsetCursor { offset, first })
     }
 }
@@ -120,6 +130,12 @@ impl Cursor for OffsetCursor {
 impl Display for OffsetCursor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_raw_string())
+    }
+}
+
+impl Default for OffsetCursor {
+    fn default() -> Self {
+        OffsetCursor { offset: 0, first: None }
     }
 }
 
@@ -149,6 +165,12 @@ impl Display for StringCursor {
     }
 }
 
+impl Default for StringCursor {
+    fn default() -> Self {
+        StringCursor { value: "".to_string() }
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -157,13 +179,13 @@ mod tests {
 
     #[test]
     fn test_offset_cursor_raw_string() {
-        let cursor = OffsetCursor { offset: 1, first: 10 };
+        let cursor = OffsetCursor { offset: 1, first: Some(10) };
         assert_eq!(cursor.to_string(), "offset:1:10");
     }
 
     #[test]
     fn test_offset_cursor_encoded_string() {
-        let cursor = OffsetCursor { offset: 1, first: 10 };
+        let cursor = OffsetCursor { offset: 1, first: Some(10) };
         assert_eq!(cursor.to_encoded_string(), "b2Zmc2V0OjE6MTA=");
     }
 
@@ -171,7 +193,7 @@ mod tests {
     fn test_offset_cursor_from_encoded_string() {
         let cursor = OffsetCursor::from_encoded_string("b2Zmc2V0OjE6MTA=").unwrap();
         assert_eq!(cursor.offset, 1);
-        assert_eq!(cursor.first, 10);
+        assert_eq!(cursor.first, Some(10));
     }
 
     #[test]

--- a/juniper_relay_helpers/src/edges.rs
+++ b/juniper_relay_helpers/src/edges.rs
@@ -1,0 +1,12 @@
+use crate::Cursor;
+
+/// Trait encapsulating common parts of a Relay Edge.
+pub trait RelayEdge {
+    type NodeType;
+
+    /// New type taking a Cursor implementation
+    fn new(node: Self::NodeType, cursor: impl Cursor) -> Self;
+
+    /// New type taking a string cursor
+    fn new_raw_cursor(node: Self::NodeType, cursor: Option<String>) -> Self;
+}

--- a/juniper_relay_helpers/src/identifier.rs
+++ b/juniper_relay_helpers/src/identifier.rs
@@ -76,8 +76,6 @@ impl<T, TD> RelayIdentifier<T, TD> where T: Display, T: FromStr, TD: Display, TD
 
 #[cfg(test)]
 mod tests {
-    use std::fmt::{Display, Formatter};
-    use std::str::FromStr;
     use base64::Engine;
     use base64::prelude::BASE64_URL_SAFE;
     use uuid::Uuid;
@@ -158,7 +156,7 @@ mod tests {
 
     #[test]
     fn test_invalid_identifier_format() {
-        let input = BASE64_URL_SAFE.encode("character//123".to_string());
+        let input = BASE64_URL_SAFE.encode("character//123");
         let result = RelayIdentifier::<String, TestTypeDiscriminator>::from_input(&input);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().to_string(), "Invalid Relay identifier");

--- a/juniper_relay_helpers/src/lib.rs
+++ b/juniper_relay_helpers/src/lib.rs
@@ -59,7 +59,7 @@
 //! `CursorProvider` is a trait that allows you to easily generate cursors for each of the items
 //! in the result set.
 //!
-//! todo().
+//! For a reference implementation, see the `OffsetCursorProvider` struct.
 //!
 //! # Identifiers
 //!
@@ -156,6 +156,24 @@
 //! 	cursor: String!
 //! 	node: PlayableCharacter!
 //! }
+//! ```
+//!
+//! ## IdentifierTypeDiscriminator
+//!
+//! To be able to use an `enum` as your identifier discriminator, you need to implement a couple of traits.
+//! Or, the easier path, just add the `IdentifierTypeDiscriminator` derive macro:
+//!
+//! ```
+//! use juniper_relay_helpers::{IdentifierTypeDiscriminator, RelayIdentifier};
+//!
+//! #[derive(IdentifierTypeDiscriminator)]
+//! enum MyEntityTypes {
+//!     CHARACTER,
+//!     ENEMY
+//! }
+//!
+//! // This can now be used in RelayIdentifier:
+//! let id = RelayIdentifier::new("123".to_string(), MyEntityTypes::CHARACTER);
 //! ```
 //!
 //!

--- a/juniper_relay_helpers/src/lib.rs
+++ b/juniper_relay_helpers/src/lib.rs
@@ -180,3 +180,4 @@ pub use cursor_errors::*;
 pub use identifier::*;
 pub use connections::*;
 pub use edges::*;
+pub use cursor_provider::*;

--- a/juniper_relay_helpers/src/lib.rs
+++ b/juniper_relay_helpers/src/lib.rs
@@ -160,18 +160,23 @@
 //!
 //!
 
+extern crate self as juniper_relay_helpers;
+
 mod pagination;
 mod cursors;
 mod cursor_errors;
 mod cursor_provider;
 mod identifier;
 mod connections;
+mod edges;
 
 // From other crates in the workspace:
-pub use juniper_relay_helpers_codegen::*;
+pub use juniper_relay_helpers_codegen::{RelayConnection, IdentifierTypeDiscriminator};
 
 // From this crate:
 pub use pagination::*;
 pub use cursors::*;
 pub use cursor_errors::*;
 pub use identifier::*;
+pub use connections::*;
+pub use edges::*;

--- a/juniper_relay_helpers/src/lib.rs
+++ b/juniper_relay_helpers/src/lib.rs
@@ -153,8 +153,8 @@
 //! }
 //!
 //! type PlayableCharacterEdge {
-//! 	cursor: String!
-//! 	node: PlayableCharacter!
+//!     cursor: String!
+//!     node: PlayableCharacter!
 //! }
 //! ```
 //!

--- a/juniper_relay_helpers/src/pagination.rs
+++ b/juniper_relay_helpers/src/pagination.rs
@@ -57,6 +57,18 @@ pub struct PageRequest {
 }
 
 impl PageRequest {
+    /// Helper method to build from the component parts from a query resolver
+    pub fn new(first: Option<i32>, after: Option<impl Cursor>) -> Self {
+        PageRequest {
+            first,
+            after: if let Some(after) = after {
+                Some(after.to_encoded_string())
+            } else {
+                None
+            }
+        }
+    }
+
     /// Parses the `after` portion of the PageRequest into the appropriate cursor type.
     /// Will return `None` if the `Option` is empty, and returns wrapped in a `Result` in case the
     /// decoding of the cursor fails.
@@ -72,7 +84,14 @@ impl PageRequest {
 
 #[cfg(test)]
 mod tests {
-    use crate::{OffsetCursor, PageRequest};
+    use crate::{OffsetCursor, PageRequest, StringCursor};
+
+    #[test]
+    fn test_new() {
+        let pr = PageRequest::new(Some(10), Some(StringCursor::new("some-string-cursor".to_string())));
+        assert_eq!(pr.first, Some(10));
+        assert_eq!(pr.after, Some("c3RyaW5nOnNvbWUtc3RyaW5nLWN1cnNvcg==".to_string()));
+    }
 
     #[test]
     fn test_decoding_cursor_from_page_request() {

--- a/juniper_relay_helpers/src/pagination.rs
+++ b/juniper_relay_helpers/src/pagination.rs
@@ -49,11 +49,11 @@ pub struct PageInfo {
 pub struct PageRequest {
     /// The number of items to return.
     #[graphql(description = "The number of items to return.")]
-    first: Option<i32>,
+    pub first: Option<i32>,
 
     /// A cursor to use as the pointer to the start of the page.
     #[graphql(description = "A cursor to use as the pointer to the start of the page.")]
-    after: Option<String>,
+    pub after: Option<String>,
 }
 
 impl PageRequest {

--- a/juniper_relay_helpers/src/pagination.rs
+++ b/juniper_relay_helpers/src/pagination.rs
@@ -61,11 +61,7 @@ impl PageRequest {
     pub fn new(first: Option<i32>, after: Option<impl Cursor>) -> Self {
         PageRequest {
             first,
-            after: if let Some(after) = after {
-                Some(after.to_encoded_string())
-            } else {
-                None
-            }
+            after: after.map(|after| after.to_encoded_string())
         }
     }
 

--- a/juniper_relay_helpers_codegen/src/lib.rs
+++ b/juniper_relay_helpers_codegen/src/lib.rs
@@ -135,15 +135,15 @@ pub fn macro_type_discriminator(input: TokenStream) -> TokenStream {
             });
 
             quote! {
-                impl Display for #enum_name {
-                    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                impl std::fmt::Display for #enum_name {
+                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                         match self {
                             #(#enum_display_variants),*
                         }
                     }
                 }
 
-                impl FromStr for #enum_name {
+                impl std::str::FromStr for #enum_name {
                     type Err = &'static str;
                     fn from_str(s: &str) -> Result<Self, Self::Err> {
                         match s {

--- a/juniper_relay_helpers_codegen/src/lib.rs
+++ b/juniper_relay_helpers_codegen/src/lib.rs
@@ -27,7 +27,7 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 pub struct #connection_name {
                     pub count: i32,
                     pub edges: Vec<#edge_name>,
-                    pub page_info: PageInfo,
+                    pub page_info: juniper_relay_helpers::PageInfo,
                 }
 
                 #[derive(juniper::GraphQLObject, Debug, Clone, Eq, PartialEq)]
@@ -38,6 +38,23 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 pub struct #edge_name {
                     pub node: #struct_name,
                     pub cursor: Option<String>,
+                }
+
+                impl juniper_relay_helpers::RelayEdge for #edge_name {
+                    type NodeType = #struct_name;
+                    fn new(node: Self::NodeType, cursor: impl juniper_relay_helpers::Cursor) -> Self {
+                        Self {
+                            node: node,
+                            cursor: Some(cursor.to_encoded_string()),
+                        }
+                    }
+
+                    fn new_raw_cursor(node: Self::NodeType, cursor: Option<String>) -> Self {
+                        Self {
+                            node: node,
+                            cursor: cursor,
+                        }
+                    }
                 }
             }
         }

--- a/juniper_relay_helpers_codegen/src/lib.rs
+++ b/juniper_relay_helpers_codegen/src/lib.rs
@@ -37,7 +37,7 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                     type NodeType = #struct_name;
 
                     fn new(
-                        nodes: &Vec<#struct_name>,
+                        nodes: &[#struct_name],
                         total_items: i32,
                         cursor_provider: impl juniper_relay_helpers::CursorProvider,
                         page_request: Option<juniper_relay_helpers::PageRequest>

--- a/juniper_relay_helpers_test/src/generated_schema.rs
+++ b/juniper_relay_helpers_test/src/generated_schema.rs
@@ -2,17 +2,17 @@
 mod integration_tests {
     use googletest::prelude::*;
     use juniper::{EmptyMutation, EmptySubscription, FieldResult, GraphQLObject, RootNode};
-    use juniper_relay_helpers::{RelayConnection, PageInfo};
+    use juniper_relay_helpers::{PageInfo, RelayConnection};
 
     // ---- Define the types ----
 
     #[derive(Debug, GraphQLObject, Clone, Eq, PartialEq, RelayConnection)]
-    struct User {
+    pub struct User {
         name: String,
     }
 
     #[derive(Debug, GraphQLObject, Clone, Eq, PartialEq, RelayConnection)]
-    struct Post {
+    pub struct Post {
         title: String,
     }
 

--- a/juniper_relay_helpers_test/src/main.rs
+++ b/juniper_relay_helpers_test/src/main.rs
@@ -164,7 +164,7 @@ mod integration_tests {
             response.assert_status_ok();
 
             // Verify the shape of the response
-            let character_test_data = crate::get_character_test_data();
+            let character_test_data = get_character_test_data();
             response.assert_json(&json!({
                 "data": expect_json::object().contains(json!({
                     "characters": expect_json::object().contains(json!({
@@ -203,7 +203,7 @@ mod integration_tests {
             response.assert_status_ok();
 
             // Verify the shape of the response
-            let location_test_data = crate::get_location_test_data();
+            let location_test_data = get_location_test_data();
             response.assert_json(&json!({
                 "data": expect_json::object().contains(json!({
                     "locations": expect_json::object().contains(json!({

--- a/juniper_relay_helpers_test/src/schema/character.rs
+++ b/juniper_relay_helpers_test/src/schema/character.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use juniper::GraphQLObject;
 use uuid::Uuid;
-use juniper_relay_helpers::{RelayConnection, RelayIdentifier, PageInfo};
+use juniper_relay_helpers::{RelayConnection, RelayIdentifier};
 
 use crate::schema::identifiers::{EntityType};
 

--- a/juniper_relay_helpers_test/src/schema/identifiers.rs
+++ b/juniper_relay_helpers_test/src/schema/identifiers.rs
@@ -1,5 +1,3 @@
-use std::fmt::{Display, Formatter};
-use std::str::FromStr;
 use juniper_relay_helpers::IdentifierTypeDiscriminator;
 
 /// Relay identifier types for this application

--- a/juniper_relay_helpers_test/src/schema/location.rs
+++ b/juniper_relay_helpers_test/src/schema/location.rs
@@ -1,5 +1,5 @@
 use juniper::GraphQLObject;
-use juniper_relay_helpers::{RelayConnection, RelayIdentifier, PageInfo};
+use juniper_relay_helpers::{RelayConnection, RelayIdentifier};
 
 use crate::schema::identifiers::{EntityType};
 

--- a/juniper_relay_helpers_test/src/schema/location.rs
+++ b/juniper_relay_helpers_test/src/schema/location.rs
@@ -17,6 +17,16 @@ pub struct Location {
     pub name: String,
 }
 
+/// Implement From to give a cleaner experience;
+impl From<LocationRow> for Location {
+    fn from(row: LocationRow) -> Self {
+        Location {
+            id: RelayIdentifier::new(row.id, EntityType::Location),
+            name: row.name
+        }
+    }   
+}
+
 // ----------- Test data ------------------
 
 pub fn get_location_test_data() -> Vec<LocationRow> {

--- a/juniper_relay_helpers_test/src/schema/mod.rs
+++ b/juniper_relay_helpers_test/src/schema/mod.rs
@@ -1,8 +1,8 @@
 use juniper::{EmptyMutation, EmptySubscription, FieldResult, RootNode};
-use juniper_relay_helpers::{Cursor, OffsetCursor, PageInfo, RelayIdentifier, RelayEdge};
+use juniper_relay_helpers::{OffsetCursor, PageInfo, RelayIdentifier, RelayEdge, RelayConnection, OffsetCursorProvider};
 pub use crate::schema::character::{Character, CharacterRelayConnection, CharacterRelayEdge, CharacterRow};
 pub use crate::schema::identifiers::EntityType;
-pub use crate::schema::location::{Location, LocationRelayConnection, LocationRelayEdge, LocationRow};
+pub use crate::schema::location::{Location, LocationRelayConnection, LocationRow};
 
 mod identifiers;
 mod character;
@@ -27,6 +27,8 @@ pub struct QueryRoot;
 #[juniper::graphql_object(context = Context)]
 impl QueryRoot {
     /// Queries for all characters in the "database"
+    /// This method shows how you can manually build up the resulting structs without using
+    /// cursor providers or any of the other fancy stuff.
     async fn characters(ctx: &Context) -> FieldResult<CharacterRelayConnection> {
         Ok(CharacterRelayConnection {
             count: ctx.characters.len() as i32,
@@ -36,7 +38,7 @@ impl QueryRoot {
                             id: RelayIdentifier::new(row.id, EntityType::Character),
                             name: row.name.clone()
                         },
-                        OffsetCursor { offset: idx as i32, first: 10 }
+                        OffsetCursor { offset: idx as i32, first: Some(10) }
                     )
                 }).collect()
             ,
@@ -50,29 +52,21 @@ impl QueryRoot {
     }
 
     /// Queries for all locations in the "database"
+    /// This method makes use of cursor providers and the shortcut methods to show how much you can
+    /// hand off to the library:
     async fn locations(ctx: &Context) -> FieldResult<LocationRelayConnection> {
-        Ok(LocationRelayConnection {
-            count: ctx.locations.len() as i32,
-            edges: ctx.locations.iter().enumerate().map(|(idx, row)| {
-                LocationRelayEdge {
-                    node: Location {
-                        // Note that this is a _string_ as the identifier type, not Uuid!
-                        id: RelayIdentifier::new(row.id.clone(), EntityType::Location),
-                        name: row.name.clone()
-                    },
-                    cursor: Some(
-                        OffsetCursor { offset: idx as i32, first: 10 }.to_encoded_string()
-                    )
-                }
-            }).collect()
-            ,
-            page_info: PageInfo {
-                has_next_page: false,
-                has_prev_page: false,
-                start_cursor: None,
-                end_cursor: None
-            }
-        })
+        let nodes = ctx.locations.iter().map(|row| {
+            Location::from(row.clone())
+        }).collect::<Vec<Location>>();
+
+        Ok(
+            LocationRelayConnection::new(
+                &nodes,
+                ctx.locations.len() as i32,
+                OffsetCursorProvider::new(),
+                None
+            )
+        )
     }
 }
 

--- a/juniper_relay_helpers_test/src/schema/mod.rs
+++ b/juniper_relay_helpers_test/src/schema/mod.rs
@@ -29,7 +29,7 @@ impl QueryRoot {
     /// Queries for all characters in the "database"
     /// This method shows how you can manually build up the resulting structs without using
     /// cursor providers or any of the other fancy stuff.
-    async fn characters(first: Option<i32>, after: Option<OffsetCursor>, ctx: &Context) -> FieldResult<CharacterRelayConnection> {
+    async fn characters(ctx: &Context) -> FieldResult<CharacterRelayConnection> {
         Ok(CharacterRelayConnection {
             count: ctx.characters.len() as i32,
             edges: ctx.characters.iter().enumerate().map(|(idx, row)| {

--- a/juniper_relay_helpers_test/src/schema/mod.rs
+++ b/juniper_relay_helpers_test/src/schema/mod.rs
@@ -1,5 +1,5 @@
 use juniper::{EmptyMutation, EmptySubscription, FieldResult, RootNode};
-use juniper_relay_helpers::{Cursor, OffsetCursor, PageInfo, RelayIdentifier};
+use juniper_relay_helpers::{Cursor, OffsetCursor, PageInfo, RelayIdentifier, RelayEdge};
 pub use crate::schema::character::{Character, CharacterRelayConnection, CharacterRelayEdge, CharacterRow};
 pub use crate::schema::identifiers::EntityType;
 pub use crate::schema::location::{Location, LocationRelayConnection, LocationRelayEdge, LocationRow};
@@ -31,15 +31,13 @@ impl QueryRoot {
         Ok(CharacterRelayConnection {
             count: ctx.characters.len() as i32,
             edges: ctx.characters.iter().enumerate().map(|(idx, row)| {
-                    CharacterRelayEdge {
-                        node: Character {
+                    CharacterRelayEdge::new(
+                        Character {
                             id: RelayIdentifier::new(row.id, EntityType::Character),
                             name: row.name.clone()
                         },
-                        cursor: Some(
-                            OffsetCursor { offset: idx as i32, first: 10 }.to_encoded_string()
-                        )
-                    }
+                        OffsetCursor { offset: idx as i32, first: 10 }
+                    )
                 }).collect()
             ,
             page_info: PageInfo {


### PR DESCRIPTION
Adding the `CursorProvider` trait to allow `RelayConnection` instances to [mostly] build themselves.