### PR TITLE
chore: release

### DIFF
--- a/juniper_relay_helpers/CHANGELOG.md
+++ b/juniper_relay_helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers-v0.4.0...juniper_relay_helpers-v0.5.0) - 2026-06-29
+
+### Added
+
+- [**breaking**] make count optional in connection type ([#33](https://github.com/solution10/juniper-relay-helpers/pull/33))
+
 ## [0.4.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers-v0.3.3...juniper_relay_helpers-v0.4.0) - 2026-06-28
 
 ### Added

--- a/juniper_relay_helpers/Cargo.toml
+++ b/juniper_relay_helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "juniper_relay_helpers"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 description = "Helper macros, structs and functions for working with Relay and Juniper"
@@ -16,7 +16,7 @@ keywords = ["relay", "juniper", "graphql", "server", "web"]
 
 [dependencies]
 
-juniper_relay_helpers_codegen = { path = "../juniper_relay_helpers_codegen", version = "0.4.0" }
+juniper_relay_helpers_codegen = { path = "../juniper_relay_helpers_codegen", version = "0.5.0" }
 juniper = { workspace = true }
 base64 = { workspace = true }
 uuid = {  workspace = true, features = ["v4"] }

--- a/juniper_relay_helpers_codegen/CHANGELOG.md
+++ b/juniper_relay_helpers_codegen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers_codegen-v0.4.0...juniper_relay_helpers_codegen-v0.5.0) - 2026-06-29
+
+### Added
+
+- [**breaking**] make count optional in connection type ([#33](https://github.com/solution10/juniper-relay-helpers/pull/33))
+
 ## [0.4.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers_codegen-v0.3.2...juniper_relay_helpers_codegen-v0.4.0) - 2026-06-28
 
 ### Added

--- a/juniper_relay_helpers_codegen/Cargo.toml
+++ b/juniper_relay_helpers_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "juniper_relay_helpers_codegen"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 description = "Derive macro crate for juniper_relay_helpers"


### PR DESCRIPTION



## 🤖 New release

* `juniper_relay_helpers_codegen`: 0.4.0 -> 0.5.0
* `juniper_relay_helpers`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `juniper_relay_helpers_test`: 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `juniper_relay_helpers_codegen`

<blockquote>

## [0.5.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers_codegen-v0.4.0...juniper_relay_helpers_codegen-v0.5.0) - 2026-06-29

### Added

- [**breaking**] make count optional in connection type ([#33](https://github.com/solution10/juniper-relay-helpers/pull/33))
</blockquote>

## `juniper_relay_helpers`

<blockquote>

## [0.5.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers-v0.4.0...juniper_relay_helpers-v0.5.0) - 2026-06-29

### Added

- [**breaking**] make count optional in connection type ([#33](https://github.com/solution10/juniper-relay-helpers/pull/33))
</blockquote>

## `juniper_relay_helpers_test`

<blockquote>

## [0.1.6](https://github.com/solution10/juniper-relay-helpers/releases/tag/juniper_relay_helpers_test-v0.1.6) - 2026-06-27

### Added

- add context marker to RelayConnection ([#26](https://github.com/solution10/juniper-relay-helpers/pull/26))
- adding more documentation ([#2](https://github.com/solution10/juniper-relay-helpers/pull/2))
- cursor providers ([#1](https://github.com/solution10/juniper-relay-helpers/pull/1))
- make cursors scalar types

### Fixed

- [**breaking**] not exposing `CursorByKey` trait correctly and adjusting cursor fmt ([#21](https://github.com/solution10/juniper-relay-helpers/pull/21))

### Other

- release master ([#24](https://github.com/solution10/juniper-relay-helpers/pull/24))
- release master ([#22](https://github.com/solution10/juniper-relay-helpers/pull/22))
- release master ([#20](https://github.com/solution10/juniper-relay-helpers/pull/20))
- release master ([#17](https://github.com/solution10/juniper-relay-helpers/pull/17))
- reformat ([#18](https://github.com/solution10/juniper-relay-helpers/pull/18))
- release master ([#15](https://github.com/solution10/juniper-relay-helpers/pull/15))
- release master ([#14](https://github.com/solution10/juniper-relay-helpers/pull/14))
- release master ([#6](https://github.com/solution10/juniper-relay-helpers/pull/6))
- rename crate to include juniper
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).