### PR TITLE
feat!: strict typing of cursors in Connections and PageInfo

### DIFF
--- a/juniper_relay_helpers/src/connections.rs
+++ b/juniper_relay_helpers/src/connections.rs
@@ -17,7 +17,7 @@ pub trait RelayConnection {
     fn new(
         nodes: &[Self::NodeType],
         total_items: Option<i32>,
-        cursor_provider: impl CursorProvider<Self::NodeType>,
+        cursor_provider: impl CursorProvider<Self::NodeType, CursorType = Self::CursorType>,
         page_request: Option<crate::PageRequest<Self::CursorType>>,
     ) -> Self;
 }

--- a/juniper_relay_helpers/src/connections.rs
+++ b/juniper_relay_helpers/src/connections.rs
@@ -14,17 +14,19 @@ pub trait RelayConnection {
 
     /// Builds a connection and associated edges from a Vec of the Nodes themselves. Pagination cursors
     /// can also be generated for you by providing the page info and CursorProvider trait instance.
-    fn new(
+    fn new<ProviderT>(
         nodes: &[Self::NodeType],
         total_items: Option<i32>,
-        cursor_provider: impl CursorProvider<Self::NodeType>,
+        cursor_provider: ProviderT,
         page_request: Option<crate::PageRequest<Self::CursorType>>,
-    ) -> Self;
+    ) -> Self
+    where
+        ProviderT: CursorProvider<Self::NodeType, CursorType = Self::CursorType>;
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{OffsetCursor, PageInfo};
+    use crate::{OffsetCursor};
     use juniper::GraphQLObject;
     use juniper_relay_helpers_codegen::RelayConnection;
 
@@ -39,7 +41,7 @@ mod tests {
         let conn = UserRelayConnection {
             count: Some(12),
             edges: vec![],
-            page_info: PageInfo {
+            page_info: UserRelayConnectionPageInfo {
                 start_cursor: None,
                 end_cursor: None,
                 has_prev_page: false,

--- a/juniper_relay_helpers/src/connections.rs
+++ b/juniper_relay_helpers/src/connections.rs
@@ -17,7 +17,7 @@ pub trait RelayConnection {
     fn new(
         nodes: &[Self::NodeType],
         total_items: Option<i32>,
-        cursor_provider: impl CursorProvider<Self::NodeType, CursorType = Self::CursorType>,
+        cursor_provider: impl CursorProvider<Self::NodeType>,
         page_request: Option<crate::PageRequest<Self::CursorType>>,
     ) -> Self;
 }

--- a/juniper_relay_helpers/src/connections.rs
+++ b/juniper_relay_helpers/src/connections.rs
@@ -1,4 +1,4 @@
-use crate::RelayEdge;
+use crate::{Cursor, RelayEdge};
 use crate::cursor_provider::CursorProvider;
 
 /// Common trait for Relay connections. Will be implemented by the codegen.
@@ -9,13 +9,16 @@ pub trait RelayConnection {
     /// The underlying type of Node we're Connection-ing. Will be filled in for you by the codegen.
     type NodeType;
 
+    /// The type of Cursor that this connection uses.
+    type CursorType: Cursor;
+
     /// Builds a connection and associated edges from a Vec of the Nodes themselves. Pagination cursors
     /// can also be generated for you by providing the page info and CursorProvider trait instance.
     fn new(
         nodes: &[Self::NodeType],
         total_items: Option<i32>,
         cursor_provider: impl CursorProvider<Self::NodeType>,
-        page_request: Option<crate::PageRequest>,
+        page_request: Option<crate::PageRequest<Self::CursorType>>,
     ) -> Self;
 }
 
@@ -26,6 +29,7 @@ mod tests {
     use juniper_relay_helpers_codegen::RelayConnection;
 
     #[derive(Debug, GraphQLObject, RelayConnection, Clone, Eq, PartialEq)]
+    #[relay(cursor = OffsetCursor)]
     pub struct User {
         name: String,
     }
@@ -53,10 +57,10 @@ mod tests {
             node: User {
                 name: "Lune".to_owned(),
             },
-            cursor: Some("some-string".to_owned()),
+            cursor: Some(OffsetCursor::new(527)),
         };
         assert_eq!(edge.node.name, "Lune");
-        assert_eq!(edge.cursor, Some("some-string".to_owned()));
+        assert_eq!(edge.cursor, Some(OffsetCursor::new(527)));
     }
 
     #[test]
@@ -65,18 +69,9 @@ mod tests {
             User {
                 name: "Lune".to_owned(),
             },
-            OffsetCursor::new(0),
+            OffsetCursor::new(27),
         );
         assert_eq!(edge.node.name, "Lune");
-        assert_eq!(edge.cursor, Some("b2Zmc2V0fHww".into()));
-
-        let edge2 = UserRelayEdge::new_raw_cursor(
-            User {
-                name: "Sciel".to_owned(),
-            },
-            Some("some-cursor".to_owned()),
-        );
-        assert_eq!(edge2.node.name, "Sciel");
-        assert_eq!(edge2.cursor, Some("some-cursor".into()));
+        assert_eq!(edge.cursor, Some(OffsetCursor::new(27)));
     }
 }

--- a/juniper_relay_helpers/src/cursor_provider.rs
+++ b/juniper_relay_helpers/src/cursor_provider.rs
@@ -1,5 +1,5 @@
-use crate::StringCursor;
-use juniper_relay_helpers::{Cursor, OffsetCursor, PageInfo};
+use crate::{PageInfoFactory, StringCursor};
+use juniper_relay_helpers::{Cursor, OffsetCursor};
 use crate::pagination_metadata::PaginationMetadata;
 
 /// Trait to implement when building a Relay cursor provider.
@@ -23,7 +23,9 @@ pub trait CursorProvider<ItemT> {
     ) -> Self::CursorType;
 
     /// Builds the `PageInfo` to return to the RelayConnection
-    fn get_page_info(&self, metadata: &PaginationMetadata<Self::CursorType>, items: &[ItemT]) -> PageInfo<Self::CursorType>;
+    fn get_page_info<PageInfoType>(&self, metadata: &PaginationMetadata<Self::CursorType>, items: &[ItemT]) -> PageInfoType
+    where
+        PageInfoType: PageInfoFactory<Self::CursorType>;
 }
 
 // -------------- OffsetCursorProvider ---------------
@@ -39,7 +41,7 @@ impl<ItemT> CursorProvider<ItemT> for OffsetCursorProvider {
         metadata: &PaginationMetadata<OffsetCursor>,
         item_idx: i32,
         _item: &ItemT,
-    ) -> Self::CursorType {
+    ) -> OffsetCursor {
         // OK this is annoying. If there _was_ a cursor passed to `after`, the offset needs to start
         // at the next item. If there wasn't, the offset needs to start at the first item (0).
         let mut offset_adjust = 0;
@@ -59,7 +61,10 @@ impl<ItemT> CursorProvider<ItemT> for OffsetCursorProvider {
         OffsetCursor::new(current_cursor.offset + offset_adjust + item_idx)
     }
 
-    fn get_page_info(&self, metadata: &PaginationMetadata<OffsetCursor>, items: &[ItemT]) -> PageInfo<Self::CursorType> {
+    fn get_page_info<PageInfoType>(&self, metadata: &PaginationMetadata<OffsetCursor>, items: &[ItemT]) -> PageInfoType
+    where
+        PageInfoType: PageInfoFactory<OffsetCursor>
+    {
         let default_cursor = OffsetCursor::default();
         let current_cursor = metadata.clone().page_request
             .and_then(|pr| pr.current_cursor())
@@ -77,25 +82,25 @@ impl<ItemT> CursorProvider<ItemT> for OffsetCursorProvider {
             false
         };
 
-        PageInfo {
-            has_prev_page: current_cursor.offset > 0,
+        PageInfoType::new(
+            current_cursor.offset > 0,
             has_next_page,
-            start_cursor: if !items.is_empty() {
+            if !items.is_empty() {
                 Some(
                     self.get_cursor_for_item(metadata, 0, &items[0]),
                 )
             } else {
                 None
             },
-            end_cursor: if !items.is_empty() {
+            if !items.is_empty() {
                 let last_index = items.len() - 1;
                 Some(
                     self.get_cursor_for_item(metadata, last_index as i32, &items[last_index]),
                 )
             } else {
                 None
-            },
-        }
+            }
+        )
     }
 }
 
@@ -138,16 +143,19 @@ where
 
     fn get_cursor_for_item(
         &self,
-        _metadata: &PaginationMetadata<Self::CursorType>,
+        _metadata: &PaginationMetadata<StringCursor>,
         _item_idx: i32,
         item: &ItemT,
-    ) -> Self::CursorType {
+    ) -> StringCursor {
         StringCursor::new(item.cursor_key())
     }
 
-    fn get_page_info(&self, metadata: &PaginationMetadata<Self::CursorType>, items: &[ItemT]) -> PageInfo<Self::CursorType> {
-        let mut first_item_cursor: Option<Self::CursorType> = None;
-        let mut last_item_cursor: Option<Self::CursorType> = None;
+    fn get_page_info<PageInfoType>(&self, metadata: &PaginationMetadata<StringCursor>, items: &[ItemT]) -> PageInfoType
+    where
+        PageInfoType: PageInfoFactory<StringCursor>
+    {
+        let mut first_item_cursor: Option<StringCursor> = None;
+        let mut last_item_cursor: Option<StringCursor> = None;
 
         if let Some(first_item) = items.first() {
             first_item_cursor = Some(
@@ -168,27 +176,24 @@ where
             has_previous_page = true;
         }
 
-        PageInfo {
-            start_cursor: first_item_cursor,
-            end_cursor: last_item_cursor,
-            has_prev_page: has_previous_page,
-            has_next_page: !items.is_empty(),
-        }
+        PageInfoType::new(has_previous_page, !items.is_empty(), first_item_cursor, last_item_cursor)
     }
 }
 
 #[cfg(test)]
 mod tests {
     mod offset_cursor_provider {
+        use juniper_relay_helpers_codegen::RelayConnection;
         use crate::{
-            Cursor, CursorProvider, OffsetCursor, OffsetCursorProvider, PageRequest,
+            CursorProvider, OffsetCursor, OffsetCursorProvider, PageRequest,
             PaginationMetadata,
         };
+        use juniper::{ GraphQLObject };
 
-        #[derive(Debug, Clone)]
-        struct Location {
-            #[allow(dead_code)]
-            name: String,
+        #[derive(Debug, Clone, GraphQLObject, RelayConnection)]
+        #[relay(cursor = OffsetCursor)]
+        pub struct Location {
+            pub name: String,
         }
 
         fn data() -> Vec<Location> {
@@ -207,7 +212,7 @@ mod tests {
         #[test]
         fn test_page_info_no_request() {
             let p = OffsetCursorProvider::new();
-            let pi = p.get_page_info(
+            let pi = p.get_page_info::<LocationRelayConnectionPageInfo>(
                 &PaginationMetadata {
                     total_count: Some(2),
                     page_request: None,
@@ -237,7 +242,7 @@ mod tests {
         #[test]
         fn test_page_info_no_request_mismatch_results_count() {
             let p = OffsetCursorProvider::new();
-            let pi = p.get_page_info(
+            let pi = p.get_page_info::<LocationRelayConnectionPageInfo>(
                 &PaginationMetadata {
                     total_count: Some(27),
                     page_request: None,
@@ -265,7 +270,7 @@ mod tests {
         #[test]
         fn test_page_info_has_request_first_page() {
             let p = OffsetCursorProvider::new();
-            let pi = p.get_page_info(
+            let pi = p.get_page_info::<LocationRelayConnectionPageInfo>(
                 &PaginationMetadata {
                     total_count: Some(27),
                     page_request: Some(PageRequest {
@@ -316,7 +321,7 @@ mod tests {
                 },
             ];
 
-            let pi1 = p.get_page_info(
+            let pi1 = p.get_page_info::<LocationRelayConnectionPageInfo>(
                 &PaginationMetadata {
                     total_count: Some(total_items),
                     page_request: Some(PageRequest {
@@ -342,7 +347,7 @@ mod tests {
                 )
             );
 
-            let pi2 = p.get_page_info(
+            let pi2 = p.get_page_info::<LocationRelayConnectionPageInfo>(
                 &PaginationMetadata {
                     total_count: Some(total_items),
                     page_request: Some(PageRequest {
@@ -368,7 +373,7 @@ mod tests {
                 )
             );
 
-            let pi3 = p.get_page_info(
+            let pi3 = p.get_page_info::<LocationRelayConnectionPageInfo>(
                 &PaginationMetadata {
                     total_count: Some(total_items),
                     page_request: Some(PageRequest {
@@ -401,7 +406,7 @@ mod tests {
             let total_items = 0;
             let data: Vec<String> = vec![];
 
-            let pi1 = p.get_page_info(
+            let pi1 = p.get_page_info::<LocationRelayConnectionPageInfo>(
                 &PaginationMetadata {
                     total_count: Some(total_items),
                     page_request: Some(PageRequest {
@@ -501,11 +506,11 @@ mod tests {
                 }),
             };
 
-            let page_info = p.get_page_info(&meta, &items);
+            let page_info = p.get_page_info::<NoSQLItemRelayConnectionPageInfo>(&meta, &items);
             assert!(!page_info.has_prev_page);
             assert!(page_info.has_next_page); // assume next is true due to items being returned.
-            assert_eq!(page_info.start_cursor, Some(StringCursor::new("c3RyaW5nfHxpZC0x".to_string())));
-            assert_eq!(page_info.end_cursor, Some(StringCursor::new("c3RyaW5nfHxpZC0z".to_string())));
+            assert_eq!(page_info.start_cursor, Some(StringCursor::new("id-1".to_string())));
+            assert_eq!(page_info.end_cursor, Some(StringCursor::new("id-3".to_string())));
         }
 
         #[test]
@@ -532,11 +537,11 @@ mod tests {
                 }),
             };
 
-            let page_info = p.get_page_info(&meta, &items);
+            let page_info = p.get_page_info::<NoSQLItemRelayConnectionPageInfo>(&meta, &items);
             assert!(!page_info.has_prev_page);
             assert!(page_info.has_next_page);
-            assert_eq!(page_info.start_cursor, Some(StringCursor::new("c3RyaW5nfHxpZC0x".to_string())));
-            assert_eq!(page_info.end_cursor, Some(StringCursor::new("c3RyaW5nfHxpZC0z".to_string())));
+            assert_eq!(page_info.start_cursor, Some(StringCursor::new("id-1".to_string())));
+            assert_eq!(page_info.end_cursor, Some(StringCursor::new("id-3".to_string())));
         }
 
         #[test]
@@ -553,7 +558,7 @@ mod tests {
                 }),
             };
 
-            let page_info = p.get_page_info(&meta, &items);
+            let page_info = p.get_page_info::<NoSQLItemRelayConnectionPageInfo>(&meta, &items);
             assert!(page_info.has_prev_page);
             assert!(!page_info.has_next_page);
             assert_eq!(page_info.start_cursor, None);

--- a/juniper_relay_helpers/src/cursor_provider.rs
+++ b/juniper_relay_helpers/src/cursor_provider.rs
@@ -468,13 +468,13 @@ mod tests {
             };
 
             let i1_cursor = p.get_cursor_for_item(&meta, 0, &items[0]);
-            assert_eq!(i1_cursor, StringCursor::new("c3RyaW5nfHxpZC0x".to_string()));
+            assert_eq!(i1_cursor.to_encoded_string(), "c3RyaW5nfHxpZC0x");
 
             let i2_cursor = p.get_cursor_for_item(&meta, 1, &items[1]);
-            assert_eq!(i2_cursor, StringCursor::new("c3RyaW5nfHxpZC0y".to_string()));
+            assert_eq!(i2_cursor.to_encoded_string(), "c3RyaW5nfHxpZC0y");
 
             let i3_cursor = p.get_cursor_for_item(&meta, 2, &items[2]);
-            assert_eq!(i3_cursor, StringCursor::new("c3RyaW5nfHxpZC0z".to_string()));
+            assert_eq!(i3_cursor.to_encoded_string(), "c3RyaW5nfHxpZC0z");
         }
 
         #[test]

--- a/juniper_relay_helpers/src/cursor_provider.rs
+++ b/juniper_relay_helpers/src/cursor_provider.rs
@@ -8,6 +8,8 @@ use crate::pagination_metadata::PaginationMetadata;
 /// within the result set, without needing to do a pass and build them manually.
 ///
 pub trait CursorProvider<ItemT> {
+    type CursorType: Cursor;
+
     /// Build a cursor instance for the given item, with helper metadata etc.
     ///
     /// `metadata` is information about the current resultset we're building for.
@@ -15,13 +17,13 @@ pub trait CursorProvider<ItemT> {
     /// `item` is the item itself.
     fn get_cursor_for_item(
         &self,
-        metadata: &PaginationMetadata,
+        metadata: &PaginationMetadata<Self::CursorType>,
         item_idx: i32,
         item: &ItemT,
-    ) -> impl Cursor;
+    ) -> Self::CursorType;
 
     /// Builds the `PageInfo` to return to the RelayConnection
-    fn get_page_info(&self, metadata: &PaginationMetadata, items: &[ItemT]) -> PageInfo;
+    fn get_page_info(&self, metadata: &PaginationMetadata<Self::CursorType>, items: &[ItemT]) -> PageInfo<Self::CursorType>;
 }
 
 // -------------- OffsetCursorProvider ---------------
@@ -30,27 +32,26 @@ pub trait CursorProvider<ItemT> {
 /// your own cursor providers too.
 pub struct OffsetCursorProvider;
 impl<ItemT> CursorProvider<ItemT> for OffsetCursorProvider {
+    type CursorType = OffsetCursor;
+
     fn get_cursor_for_item(
         &self,
-        metadata: &PaginationMetadata,
+        metadata: &PaginationMetadata<OffsetCursor>,
         item_idx: i32,
         _item: &ItemT,
-    ) -> impl Cursor {
+    ) -> Self::CursorType {
         // OK this is annoying. If there _was_ a cursor passed to `after`, the offset needs to start
         // at the next item. If there wasn't, the offset needs to start at the first item (0).
         let mut offset_adjust = 0;
 
         let default_cursor = OffsetCursor::default();
         let current_cursor = match &metadata.page_request {
-            Some(pr) => match pr.parsed_cursor() {
-                Ok(c) => match c {
-                    Some(cc) => {
-                        offset_adjust = 1;
-                        cc
-                    }
-                    None => default_cursor,
-                },
-                Err(_) => default_cursor,
+            Some(pr) => match pr.current_cursor() {
+                Some(cc) => {
+                    offset_adjust = 1;
+                    cc
+                }
+                None => default_cursor,
             },
             None => default_cursor,
         };
@@ -58,15 +59,11 @@ impl<ItemT> CursorProvider<ItemT> for OffsetCursorProvider {
         OffsetCursor::new(current_cursor.offset + offset_adjust + item_idx)
     }
 
-    fn get_page_info(&self, metadata: &PaginationMetadata, items: &[ItemT]) -> PageInfo {
+    fn get_page_info(&self, metadata: &PaginationMetadata<OffsetCursor>, items: &[ItemT]) -> PageInfo<Self::CursorType> {
         let default_cursor = OffsetCursor::default();
-        let current_cursor = match &metadata.page_request {
-            Some(pr) => match pr.parsed_cursor() {
-                Ok(c) => c.unwrap_or(default_cursor),
-                Err(_) => default_cursor,
-            },
-            None => default_cursor,
-        };
+        let current_cursor = metadata.clone().page_request
+            .and_then(|pr| pr.current_cursor())
+            .unwrap_or(default_cursor);
 
         let has_next_page = if let Some(pr) = &metadata.page_request {
             // Check if we requested up to or over the total items.
@@ -85,8 +82,7 @@ impl<ItemT> CursorProvider<ItemT> for OffsetCursorProvider {
             has_next_page,
             start_cursor: if !items.is_empty() {
                 Some(
-                    self.get_cursor_for_item(metadata, 0, &items[0])
-                        .to_encoded_string(),
+                    self.get_cursor_for_item(metadata, 0, &items[0]),
                 )
             } else {
                 None
@@ -94,8 +90,7 @@ impl<ItemT> CursorProvider<ItemT> for OffsetCursorProvider {
             end_cursor: if !items.is_empty() {
                 let last_index = items.len() - 1;
                 Some(
-                    self.get_cursor_for_item(metadata, last_index as i32, &items[last_index])
-                        .to_encoded_string(),
+                    self.get_cursor_for_item(metadata, last_index as i32, &items[last_index]),
                 )
             } else {
                 None
@@ -139,30 +134,30 @@ impl<ItemT> CursorProvider<ItemT> for KeyedCursorProvider
 where
     ItemT: CursorByKey,
 {
+    type CursorType = StringCursor;
+
     fn get_cursor_for_item(
         &self,
-        _metadata: &PaginationMetadata,
+        _metadata: &PaginationMetadata<Self::CursorType>,
         _item_idx: i32,
         item: &ItemT,
-    ) -> impl Cursor {
+    ) -> Self::CursorType {
         StringCursor::new(item.cursor_key())
     }
 
-    fn get_page_info(&self, metadata: &PaginationMetadata, items: &[ItemT]) -> PageInfo {
-        let mut first_item_cursor: Option<String> = None;
-        let mut last_item_cursor: Option<String> = None;
+    fn get_page_info(&self, metadata: &PaginationMetadata<Self::CursorType>, items: &[ItemT]) -> PageInfo<Self::CursorType> {
+        let mut first_item_cursor: Option<Self::CursorType> = None;
+        let mut last_item_cursor: Option<Self::CursorType> = None;
 
         if let Some(first_item) = items.first() {
             first_item_cursor = Some(
-                self.get_cursor_for_item(metadata, 0, first_item)
-                    .to_encoded_string(),
+                self.get_cursor_for_item(metadata, 0, first_item),
             );
         }
 
         if let Some(last_item) = items.last() {
             last_item_cursor = Some(
-                self.get_cursor_for_item(metadata, items.len() as i32 - 1, last_item)
-                    .to_encoded_string(),
+                self.get_cursor_for_item(metadata, items.len() as i32 - 1, last_item),
             );
         }
 
@@ -226,14 +221,12 @@ mod tests {
                 pi.start_cursor,
                 Some(
                     OffsetCursor::new(0)
-                    .to_encoded_string()
                 )
             );
             assert_eq!(
                 pi.end_cursor,
                 Some(
                     OffsetCursor::new(1)
-                    .to_encoded_string()
                 )
             );
         }
@@ -258,14 +251,12 @@ mod tests {
                 pi.start_cursor,
                 Some(
                     OffsetCursor::new(0)
-                    .to_encoded_string()
                 )
             );
             assert_eq!(
                 pi.end_cursor,
                 Some(
                     OffsetCursor::new(1)
-                    .to_encoded_string()
                 )
             );
         }
@@ -280,6 +271,7 @@ mod tests {
                     page_request: Some(PageRequest {
                         first: Some(10),
                         after: None,
+                        before: None,
                     }),
                 },
                 &data(),
@@ -291,14 +283,12 @@ mod tests {
                 pi.start_cursor,
                 Some(
                     OffsetCursor::new(0)
-                    .to_encoded_string()
                 )
             );
             assert_eq!(
                 pi.end_cursor,
                 Some(
                     OffsetCursor::new(1)
-                    .to_encoded_string()
                 )
             );
         }
@@ -332,6 +322,7 @@ mod tests {
                     page_request: Some(PageRequest {
                         first: Some(5),
                         after: None,
+                        before: None,
                     }),
                 },
                 &data,
@@ -342,14 +333,12 @@ mod tests {
                 pi1.start_cursor,
                 Some(
                     OffsetCursor::new(0)
-                    .to_encoded_string()
                 )
             );
             assert_eq!(
                 pi1.end_cursor,
                 Some(
                     OffsetCursor::new(4)
-                    .to_encoded_string()
                 )
             );
 
@@ -359,6 +348,7 @@ mod tests {
                     page_request: Some(PageRequest {
                         first: Some(5),
                         after: pi1.end_cursor.clone(),
+                        before: None,
                     }),
                 },
                 &data,
@@ -369,14 +359,12 @@ mod tests {
                 pi2.start_cursor,
                 Some(
                     OffsetCursor::new(5)
-                    .to_encoded_string()
                 )
             );
             assert_eq!(
                 pi2.end_cursor,
                 Some(
                     OffsetCursor::new(9)
-                    .to_encoded_string()
                 )
             );
 
@@ -386,6 +374,7 @@ mod tests {
                     page_request: Some(PageRequest {
                         first: Some(5),
                         after: pi2.end_cursor.clone(),
+                        before: None,
                     }),
                 },
                 &[data[0].clone(), data[1].clone(), data[2].clone()],
@@ -396,14 +385,12 @@ mod tests {
                 pi3.start_cursor,
                 Some(
                     OffsetCursor::new(10)
-                    .to_encoded_string()
                 )
             );
             assert_eq!(
                 pi3.end_cursor,
                 Some(
                     OffsetCursor::new(12)
-                    .to_encoded_string()
                 )
             );
         }
@@ -420,6 +407,7 @@ mod tests {
                     page_request: Some(PageRequest {
                         first: Some(5),
                         after: None,
+                        before: None,
                     }),
                 },
                 &data,
@@ -475,6 +463,7 @@ mod tests {
                 page_request: Some(PageRequest::new(
                     Some(10),
                     Some(StringCursor::new("".to_string())),
+                    None
                 )),
             };
 
@@ -508,14 +497,15 @@ mod tests {
                 page_request: Some(PageRequest {
                     first: Some(10),
                     after: None,
+                    before: None,
                 }),
             };
 
             let page_info = p.get_page_info(&meta, &items);
             assert!(!page_info.has_prev_page);
             assert!(page_info.has_next_page); // assume next is true due to items being returned.
-            assert_eq!(page_info.start_cursor, Some("c3RyaW5nfHxpZC0x".to_string()));
-            assert_eq!(page_info.end_cursor, Some("c3RyaW5nfHxpZC0z".to_string()));
+            assert_eq!(page_info.start_cursor, Some(StringCursor::new("c3RyaW5nfHxpZC0x".to_string())));
+            assert_eq!(page_info.end_cursor, Some(StringCursor::new("c3RyaW5nfHxpZC0z".to_string())));
         }
 
         #[test]
@@ -538,14 +528,15 @@ mod tests {
                 page_request: Some(PageRequest {
                     first: Some(10),
                     after: None,
+                    before: None,
                 }),
             };
 
             let page_info = p.get_page_info(&meta, &items);
             assert!(!page_info.has_prev_page);
             assert!(page_info.has_next_page);
-            assert_eq!(page_info.start_cursor, Some("c3RyaW5nfHxpZC0x".to_string()));
-            assert_eq!(page_info.end_cursor, Some("c3RyaW5nfHxpZC0z".to_string()));
+            assert_eq!(page_info.start_cursor, Some(StringCursor::new("c3RyaW5nfHxpZC0x".to_string())));
+            assert_eq!(page_info.end_cursor, Some(StringCursor::new("c3RyaW5nfHxpZC0z".to_string())));
         }
 
         #[test]
@@ -557,7 +548,8 @@ mod tests {
                 total_count: Some(30), // More than the items returned, we have more items
                 page_request: Some(PageRequest {
                     first: Some(10),                             // More than items returned
-                    after: Some("c3RyaW5nOmlkLTA=".to_string()), // id-0 - we're paginating.
+                    after: Some(StringCursor::new("c3RyaW5nOmlkLTA=".to_string())), // id-0 - we're paginating.
+                    before: None,
                 }),
             };
 

--- a/juniper_relay_helpers/src/cursor_provider.rs
+++ b/juniper_relay_helpers/src/cursor_provider.rs
@@ -468,13 +468,13 @@ mod tests {
             };
 
             let i1_cursor = p.get_cursor_for_item(&meta, 0, &items[0]);
-            assert_eq!(i1_cursor.to_encoded_string(), "c3RyaW5nfHxpZC0x");
+            assert_eq!(i1_cursor, StringCursor::new("c3RyaW5nfHxpZC0x".to_string()));
 
             let i2_cursor = p.get_cursor_for_item(&meta, 1, &items[1]);
-            assert_eq!(i2_cursor.to_encoded_string(), "c3RyaW5nfHxpZC0y");
+            assert_eq!(i2_cursor, StringCursor::new("c3RyaW5nfHxpZC0y".to_string()));
 
             let i3_cursor = p.get_cursor_for_item(&meta, 2, &items[2]);
-            assert_eq!(i3_cursor.to_encoded_string(), "c3RyaW5nfHxpZC0z");
+            assert_eq!(i3_cursor, StringCursor::new("c3RyaW5nfHxpZC0z".to_string()));
         }
 
         #[test]

--- a/juniper_relay_helpers/src/cursors.rs
+++ b/juniper_relay_helpers/src/cursors.rs
@@ -5,35 +5,3 @@ mod string_cursor;
 pub use cursor::*;
 pub use offset_cursor::*;
 pub use string_cursor::*;
-
-#[cfg(test)]
-mod tests {
-
-
-
-    mod string_cursor_tests {
-        use crate::{Cursor, StringCursor};
-
-        #[test]
-        fn test_string_cursor_raw_string() {
-            let cursor = StringCursor {
-                value: "some-cursor".to_string(),
-            };
-            assert_eq!(cursor.to_string(), "string||some-cursor");
-        }
-
-        #[test]
-        fn test_string_cursor_encoded_string() {
-            let cursor = StringCursor {
-                value: "some-cursor".to_string(),
-            };
-            assert_eq!(cursor.to_encoded_string(), "c3RyaW5nfHxzb21lLWN1cnNvcg==");
-        }
-
-        #[test]
-        fn test_string_cursor_from_encoded_string() {
-            let cursor = StringCursor::from_encoded_string("c3RyaW5nfHxzb21lLWN1cnNvcg==").unwrap();
-            assert_eq!(cursor.value, "some-cursor");
-        }
-    }
-}

--- a/juniper_relay_helpers/src/cursors/cursor.rs
+++ b/juniper_relay_helpers/src/cursors/cursor.rs
@@ -1,20 +1,19 @@
 use base64::prelude::*;
-use juniper::{FromInputValue, ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue};
+use juniper::{
+    DefaultScalarValue, FromInputValue, GraphQLType, GraphQLValue, GraphQLValueAsync,
+    ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue,
+    macros::reflect::{BaseSubTypes, BaseType, WrappedType},
+    marker::IsOutputType,
+};
 use crate::CursorError;
 
 pub const CURSOR_SEGMENT_DELIMITER: &str = "||";
 
-/// Cursor struct that builds into an opaque string.
-/// Cursors are present both in the edges and in the PageInfo within the Connection.
+/// Non-generic cursor interface: serialization, deserialization, and the scalar helper methods
+/// used to wire a cursor type into `#[derive(GraphQLScalar)]`.
 ///
-/// You can implement this trait for your own cursor type if it's not covered by this library.
-/// You can also use the built-in Cursors:
-///     - OffsetCursor
-///     - StringCursor
-///
-/// This trait implements the common methods needed to be considered a `GraphQlScalar`
-/// which means you can add the following to your struct and it will work
-/// out of the box:
+/// Implement this trait on your cursor struct, then add an empty `impl<S: ScalarValue + Send + Sync> Cursor<S> for MyCursor {}`
+/// to make it usable as a typed cursor in connections.
 ///
 /// ```nocompile
 /// #[derive(Debug, GraphQLScalar)]
@@ -24,17 +23,18 @@ pub const CURSOR_SEGMENT_DELIMITER: &str = "||";
 ///     from_input_with = Self::from_input
 /// )]
 /// struct MyCursor {}
-/// impl Cursor for MyCursor { ... }
+/// impl CursorBase for MyCursor { ... }
+/// impl<S: ScalarValue + Send + Sync> Cursor<S> for MyCursor {}
 /// ```
 ///
-pub trait Cursor: Clone + FromInputValue {
+pub trait CursorBase: Clone + Sized {
     /// Concrete type of the returned cursor. Usually the thing that implements the trait.
-    type CursorType: Cursor;
+    type CursorType: CursorBase;
 
     /// Serialize the cursor into a string ready to be base64 encoded.
     fn to_raw_string(&self) -> String;
 
-    /// Constructor that given the raw string, and a vector of parts (the colon separated segments)
+    /// Constructor that given the raw string, and a vector of parts (the delimiter-separated segments)
     /// will return a Result of the CursorType. Return a CursorError if the decoding fails.
     fn new(raw: &str, parts: Vec<&str>) -> Result<Self::CursorType, CursorError>;
 
@@ -55,7 +55,7 @@ pub trait Cursor: Clone + FromInputValue {
         BASE64_URL_SAFE.encode(self.to_raw_string().as_bytes())
     }
 
-    // ------------- GraphQLScalar implementations --------------
+    // ------------- GraphQLScalar helper implementations --------------
 
     fn to_output(&self) -> String {
         self.to_encoded_string()
@@ -74,6 +74,31 @@ pub trait Cursor: Clone + FromInputValue {
     }
 }
 
+/// Marker trait that combines [`CursorBase`] with all Juniper GraphQL scalar output traits
+/// for a given scalar value type `S`.
+///
+/// Implement this as an empty impl on any cursor type that implements both `CursorBase` and
+/// `#[derive(GraphQLScalar)]`:
+///
+/// ```nocompile
+/// impl<S: ScalarValue + Send + Sync> Cursor<S> for MyCursor {}
+/// ```
+///
+pub trait Cursor<S: ScalarValue + Send + Sync = DefaultScalarValue>:
+    CursorBase
+    + Send
+    + Sync
+    + FromInputValue<S>
+    + GraphQLValue<S, TypeInfo = (), Context = ()>
+    + GraphQLType<S>
+    + IsOutputType<S>
+    + GraphQLValueAsync<S>
+    + BaseType<S>
+    + BaseSubTypes<S>
+    + WrappedType<S>
+{
+}
+
 /// Decodes a cursor from a base64 encoded string into the correct concrete instance type.
 /// Use the Turbofish `::<>()` syntax to tell the method what that correct type is.
 ///
@@ -89,8 +114,7 @@ pub trait Cursor: Clone + FromInputValue {
 ///
 pub fn cursor_from_encoded_string<T>(input: &str) -> Result<T, CursorError>
 where
-    T: Cursor<CursorType = T>,
+    T: CursorBase<CursorType = T>,
 {
-    let cursor = T::from_encoded_string(input)?;
-    Ok(cursor)
+    T::from_encoded_string(input)
 }

--- a/juniper_relay_helpers/src/cursors/cursor.rs
+++ b/juniper_relay_helpers/src/cursors/cursor.rs
@@ -1,19 +1,20 @@
 use base64::prelude::*;
-use juniper::{
-    DefaultScalarValue, FromInputValue, GraphQLType, GraphQLValue, GraphQLValueAsync,
-    ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue,
-    macros::reflect::{BaseSubTypes, BaseType, WrappedType},
-    marker::IsOutputType,
-};
+use juniper::{FromInputValue, ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue};
 use crate::CursorError;
 
 pub const CURSOR_SEGMENT_DELIMITER: &str = "||";
 
-/// Non-generic cursor interface: serialization, deserialization, and the scalar helper methods
-/// used to wire a cursor type into `#[derive(GraphQLScalar)]`.
+/// Cursor struct that builds into an opaque string.
+/// Cursors are present both in the edges and in the PageInfo within the Connection.
 ///
-/// Implement this trait on your cursor struct, then add an empty `impl<S: ScalarValue + Send + Sync> Cursor<S> for MyCursor {}`
-/// to make it usable as a typed cursor in connections.
+/// You can implement this trait for your own cursor type if it's not covered by this library.
+/// You can also use the built-in Cursors:
+///     - OffsetCursor
+///     - StringCursor
+///
+/// This trait implements the common methods needed to be considered a `GraphQlScalar`
+/// which means you can add the following to your struct and it will work
+/// out of the box:
 ///
 /// ```nocompile
 /// #[derive(Debug, GraphQLScalar)]
@@ -23,18 +24,17 @@ pub const CURSOR_SEGMENT_DELIMITER: &str = "||";
 ///     from_input_with = Self::from_input
 /// )]
 /// struct MyCursor {}
-/// impl CursorBase for MyCursor { ... }
-/// impl<S: ScalarValue + Send + Sync> Cursor<S> for MyCursor {}
+/// impl Cursor for MyCursor { ... }
 /// ```
 ///
-pub trait CursorBase: Clone + Sized {
+pub trait Cursor: Clone + FromInputValue {
     /// Concrete type of the returned cursor. Usually the thing that implements the trait.
-    type CursorType: CursorBase;
+    type CursorType: Cursor;
 
     /// Serialize the cursor into a string ready to be base64 encoded.
     fn to_raw_string(&self) -> String;
 
-    /// Constructor that given the raw string, and a vector of parts (the delimiter-separated segments)
+    /// Constructor that given the raw string, and a vector of parts (the colon separated segments)
     /// will return a Result of the CursorType. Return a CursorError if the decoding fails.
     fn new(raw: &str, parts: Vec<&str>) -> Result<Self::CursorType, CursorError>;
 
@@ -55,7 +55,7 @@ pub trait CursorBase: Clone + Sized {
         BASE64_URL_SAFE.encode(self.to_raw_string().as_bytes())
     }
 
-    // ------------- GraphQLScalar helper implementations --------------
+    // ------------- GraphQLScalar implementations --------------
 
     fn to_output(&self) -> String {
         self.to_encoded_string()
@@ -74,31 +74,6 @@ pub trait CursorBase: Clone + Sized {
     }
 }
 
-/// Marker trait that combines [`CursorBase`] with all Juniper GraphQL scalar output traits
-/// for a given scalar value type `S`.
-///
-/// Implement this as an empty impl on any cursor type that implements both `CursorBase` and
-/// `#[derive(GraphQLScalar)]`:
-///
-/// ```nocompile
-/// impl<S: ScalarValue + Send + Sync> Cursor<S> for MyCursor {}
-/// ```
-///
-pub trait Cursor<S: ScalarValue + Send + Sync = DefaultScalarValue>:
-    CursorBase
-    + Send
-    + Sync
-    + FromInputValue<S>
-    + GraphQLValue<S, TypeInfo = (), Context = ()>
-    + GraphQLType<S>
-    + IsOutputType<S>
-    + GraphQLValueAsync<S>
-    + BaseType<S>
-    + BaseSubTypes<S>
-    + WrappedType<S>
-{
-}
-
 /// Decodes a cursor from a base64 encoded string into the correct concrete instance type.
 /// Use the Turbofish `::<>()` syntax to tell the method what that correct type is.
 ///
@@ -114,7 +89,8 @@ pub trait Cursor<S: ScalarValue + Send + Sync = DefaultScalarValue>:
 ///
 pub fn cursor_from_encoded_string<T>(input: &str) -> Result<T, CursorError>
 where
-    T: CursorBase<CursorType = T>,
+    T: Cursor<CursorType = T>,
 {
-    T::from_encoded_string(input)
+    let cursor = T::from_encoded_string(input)?;
+    Ok(cursor)
 }

--- a/juniper_relay_helpers/src/cursors/cursor.rs
+++ b/juniper_relay_helpers/src/cursors/cursor.rs
@@ -1,5 +1,5 @@
 use base64::prelude::*;
-use juniper::{ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue};
+use juniper::{FromInputValue, ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue};
 use crate::CursorError;
 
 pub const CURSOR_SEGMENT_DELIMITER: &str = "||";
@@ -27,9 +27,9 @@ pub const CURSOR_SEGMENT_DELIMITER: &str = "||";
 /// impl Cursor for MyCursor { ... }
 /// ```
 ///
-pub trait Cursor {
+pub trait Cursor: Clone + FromInputValue {
     /// Concrete type of the returned cursor. Usually the thing that implements the trait.
-    type CursorType;
+    type CursorType: Cursor;
 
     /// Serialize the cursor into a string ready to be base64 encoded.
     fn to_raw_string(&self) -> String;

--- a/juniper_relay_helpers/src/cursors/offset_cursor.rs
+++ b/juniper_relay_helpers/src/cursors/offset_cursor.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
-use juniper::{GraphQLScalar, ScalarValue};
-use crate::{Cursor, CursorBase, CursorError, CURSOR_SEGMENT_DELIMITER};
+use juniper::GraphQLScalar;
+use crate::{Cursor, CursorError, CURSOR_SEGMENT_DELIMITER};
 
 /// A simple offset-based cursor.
 #[derive(Debug, GraphQLScalar, Default, Clone, Eq, PartialEq)]
@@ -57,7 +57,7 @@ impl OffsetCursor {
     }
 }
 
-impl CursorBase for OffsetCursor {
+impl Cursor for OffsetCursor {
     type CursorType = OffsetCursor;
 
     fn to_raw_string(&self) -> String {
@@ -73,8 +73,6 @@ impl CursorBase for OffsetCursor {
     }
 }
 
-impl<S: ScalarValue + Send + Sync> Cursor<S> for OffsetCursor {}
-
 impl Display for OffsetCursor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_raw_string())
@@ -83,7 +81,7 @@ impl Display for OffsetCursor {
 
 #[cfg(test)]
 mod tests {
-    use crate::cursors::{CursorBase, OffsetCursor};
+    use crate::cursors::{Cursor, OffsetCursor};
 
     #[test]
     fn test_new_offset_first() {

--- a/juniper_relay_helpers/src/cursors/offset_cursor.rs
+++ b/juniper_relay_helpers/src/cursors/offset_cursor.rs
@@ -3,7 +3,7 @@ use juniper::GraphQLScalar;
 use crate::{Cursor, CursorError, CURSOR_SEGMENT_DELIMITER};
 
 /// A simple offset-based cursor.
-#[derive(Debug, GraphQLScalar, Default, Clone)]
+#[derive(Debug, GraphQLScalar, Default, Clone, Eq, PartialEq)]
 #[graphql(
     name = "OffsetCursor",
     to_output_with = Self::to_output,

--- a/juniper_relay_helpers/src/cursors/offset_cursor.rs
+++ b/juniper_relay_helpers/src/cursors/offset_cursor.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
-use juniper::GraphQLScalar;
-use crate::{Cursor, CursorError, CURSOR_SEGMENT_DELIMITER};
+use juniper::{GraphQLScalar, ScalarValue};
+use crate::{Cursor, CursorBase, CursorError, CURSOR_SEGMENT_DELIMITER};
 
 /// A simple offset-based cursor.
 #[derive(Debug, GraphQLScalar, Default, Clone, Eq, PartialEq)]
@@ -57,7 +57,7 @@ impl OffsetCursor {
     }
 }
 
-impl Cursor for OffsetCursor {
+impl CursorBase for OffsetCursor {
     type CursorType = OffsetCursor;
 
     fn to_raw_string(&self) -> String {
@@ -73,6 +73,8 @@ impl Cursor for OffsetCursor {
     }
 }
 
+impl<S: ScalarValue + Send + Sync> Cursor<S> for OffsetCursor {}
+
 impl Display for OffsetCursor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_raw_string())
@@ -81,7 +83,7 @@ impl Display for OffsetCursor {
 
 #[cfg(test)]
 mod tests {
-    use crate::cursors::{Cursor, OffsetCursor};
+    use crate::cursors::{CursorBase, OffsetCursor};
 
     #[test]
     fn test_new_offset_first() {

--- a/juniper_relay_helpers/src/cursors/string_cursor.rs
+++ b/juniper_relay_helpers/src/cursors/string_cursor.rs
@@ -4,7 +4,7 @@ use crate::{Cursor, CursorError, CURSOR_SEGMENT_DELIMITER};
 
 /// Built-in cursor type for when the cursor is just a string. Usually useful for things like
 /// NoSQL systems that return something opaque to you.
-#[derive(Debug, GraphQLScalar, Clone)]
+#[derive(Debug, GraphQLScalar, Clone, Eq, PartialEq)]
 pub struct StringCursor {
     /// The value of the cursor.
     pub value: String,

--- a/juniper_relay_helpers/src/cursors/string_cursor.rs
+++ b/juniper_relay_helpers/src/cursors/string_cursor.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
-use juniper::GraphQLScalar;
-use crate::{Cursor, CursorError, CURSOR_SEGMENT_DELIMITER};
+use juniper::{GraphQLScalar, ScalarValue};
+use crate::{Cursor, CursorBase, CursorError, CURSOR_SEGMENT_DELIMITER};
 
 /// Built-in cursor type for when the cursor is just a string. Usually useful for things like
 /// NoSQL systems that return something opaque to you.
@@ -16,7 +16,7 @@ impl StringCursor {
     }
 }
 
-impl Cursor for StringCursor {
+impl CursorBase for StringCursor {
     type CursorType = StringCursor;
 
     fn to_raw_string(&self) -> String {
@@ -30,6 +30,8 @@ impl Cursor for StringCursor {
         })
     }
 }
+
+impl<S: ScalarValue + Send + Sync> Cursor<S> for StringCursor {}
 impl Display for StringCursor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_raw_string())
@@ -46,7 +48,7 @@ impl Default for StringCursor {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Cursor, StringCursor};
+    use crate::{CursorBase, StringCursor};
 
     #[test]
     fn test_string_cursor_raw_string() {

--- a/juniper_relay_helpers/src/cursors/string_cursor.rs
+++ b/juniper_relay_helpers/src/cursors/string_cursor.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
-use juniper::{GraphQLScalar, ScalarValue};
-use crate::{Cursor, CursorBase, CursorError, CURSOR_SEGMENT_DELIMITER};
+use juniper::GraphQLScalar;
+use crate::{Cursor, CursorError, CURSOR_SEGMENT_DELIMITER};
 
 /// Built-in cursor type for when the cursor is just a string. Usually useful for things like
 /// NoSQL systems that return something opaque to you.
@@ -16,7 +16,7 @@ impl StringCursor {
     }
 }
 
-impl CursorBase for StringCursor {
+impl Cursor for StringCursor {
     type CursorType = StringCursor;
 
     fn to_raw_string(&self) -> String {
@@ -30,8 +30,6 @@ impl CursorBase for StringCursor {
         })
     }
 }
-
-impl<S: ScalarValue + Send + Sync> Cursor<S> for StringCursor {}
 impl Display for StringCursor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_raw_string())
@@ -48,7 +46,7 @@ impl Default for StringCursor {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CursorBase, StringCursor};
+    use crate::{Cursor, StringCursor};
 
     #[test]
     fn test_string_cursor_raw_string() {

--- a/juniper_relay_helpers/src/edges.rs
+++ b/juniper_relay_helpers/src/edges.rs
@@ -3,10 +3,8 @@ use crate::Cursor;
 /// Trait encapsulating common parts of a Relay Edge.
 pub trait RelayEdge {
     type NodeType;
+    type CursorType: Cursor;
 
     /// New type taking a Cursor implementation
-    fn new(node: Self::NodeType, cursor: impl Cursor) -> Self;
-
-    /// New type taking a string cursor
-    fn new_raw_cursor(node: Self::NodeType, cursor: Option<String>) -> Self;
+    fn new(node: Self::NodeType, cursor: Self::CursorType) -> Self;
 }

--- a/juniper_relay_helpers/src/lib.rs
+++ b/juniper_relay_helpers/src/lib.rs
@@ -16,7 +16,6 @@
 //! ```rust
 //! use juniper::GraphQLObject;
 //! use juniper_relay_helpers::{RelayConnection};
-//! # use juniper_relay_helpers::PageInfo;
 //!
 //! #[derive(Debug, GraphQLObject, RelayConnection, Clone, Eq, PartialEq)]
 //! pub struct PlayableCharacter {
@@ -26,7 +25,7 @@
 //!```
 //! ```rust
 //! # use juniper::GraphQLObject;
-//! # use juniper_relay_helpers::PageInfo;
+//! # use juniper_relay_helpers::{StringCursor};
 //! # #[derive(GraphQLObject)]
 //! # pub struct PlayableCharacter {
 //! #  pub name: String
@@ -36,13 +35,21 @@
 //! struct PlayableCharacterRelayConnection {
 //!     count: i32,
 //!     edges: Vec<PlayableCharacterRelayEdge>,
-//!     page_info: PageInfo
+//!     page_info: PlayableCharacterRelayConnectionPageInfo
 //! }
 //!
 //! #[derive(GraphQLObject)]
 //! struct PlayableCharacterRelayEdge {
 //!     cursor: String,
 //!     node: PlayableCharacter,
+//! }
+//!
+//! #[derive(GraphQLObject)]
+//! struct PlayableCharacterRelayConnectionPageInfo {
+//!     pub has_next_page: bool,
+//!     pub has_prev_page: bool,
+//!     pub start_cursor: Option<StringCursor>,
+//!     pub end_cursor: Option<StringCursor>,
 //! }
 //!
 //! ```
@@ -136,14 +143,14 @@
 //!
 //! ## Page Request
 //!
-//! Pagination requests in Relay usually are specified by a ``first`` and ``after`` argument.
+//! Pagination requests in Relay usually are specified by a ``first``, ``after`` and ``before`` arguments.
 //! This library provides a `PageRequest` struct to help with this.
 //!
 //! ```
 //! use juniper_relay_helpers::{PageRequest, StringCursor};
 //! #
 //! # fn page_request() {
-//! let page_request = PageRequest::new(Some(10), Some(StringCursor::new("my-cursor".to_string())));
+//! let page_request = PageRequest::new(Some(10), Some(StringCursor::new("my-cursor".to_string())), None);
 //! # }
 //! ```
 //!
@@ -155,8 +162,8 @@
 //! Relay requires edges and pagination info to contain opaque strings called "cursors".
 //! This library provides a few built-in cursors, but you can also implement your own.
 //!
-//! The most simple cursor is the OffsetCursor, which is just an offset and a limit, similar to
-//! SQL LIMIT and OFFSET.
+//! The most simple cursor is the OffsetCursor, which is just an offset, often used in
+//! SQL OFFSET.
 //!
 //! ```
 //! # use juniper_relay_helpers::{cursor_from_encoded_string, Cursor, OffsetCursor};
@@ -309,8 +316,9 @@ mod cursor_provider;
 mod cursors;
 mod edges;
 mod identifier;
-mod pagination;
+mod page_request;
 mod pagination_metadata;
+mod page_info_factory;
 
 // From other crates in the workspace:
 pub use juniper_relay_helpers_codegen::{IdentifierTypeDiscriminator, RelayConnection};
@@ -322,5 +330,6 @@ pub use cursor_provider::*;
 pub use cursors::*;
 pub use edges::*;
 pub use identifier::*;
-pub use pagination::*;
+pub use page_info_factory::*;
+pub use page_request::*;
 pub use pagination_metadata::*;

--- a/juniper_relay_helpers/src/page_info_factory.rs
+++ b/juniper_relay_helpers/src/page_info_factory.rs
@@ -1,0 +1,8 @@
+use crate::Cursor;
+
+/// Trait used by the CursorProvider's to be able to build the generated PageInfo structs from the codegen.
+///
+/// You shouldn't need to implement it yourself, it's just used in the generated code.
+pub trait PageInfoFactory<CursorT> where CursorT: Cursor {
+    fn new(has_prev_page: bool, has_next_page: bool, start_cursor: Option<CursorT>, end_cursor: Option<CursorT>) -> Self;
+}

--- a/juniper_relay_helpers/src/page_request.rs
+++ b/juniper_relay_helpers/src/page_request.rs
@@ -1,34 +1,4 @@
 use crate::{Cursor};
-use juniper::{GraphQLObject};
-
-/// Represents the Relay spec pagination object
-/// <https://relay.dev/docs/guides/graphql-server-specification/>
-///
-#[derive(Debug, GraphQLObject, Eq, PartialEq, Clone)]
-#[graphql(description = "Pagination information")]
-pub struct PageInfo<CursorType> where CursorType: Cursor {
-    /// Indicates whether there is a page following this current one
-    #[graphql(description = "Indicates whether there is a page following this current one")]
-    pub has_next_page: bool,
-
-    /// Indicates whether there is a page preceding this one
-    #[graphql(description = "Indicates whether there is a page preceding this one")]
-    pub has_prev_page: bool,
-
-    /// An opaque cursor that when passed to after: in a query will return the previous page of
-    /// results.
-    #[graphql(
-        description = "An opaque cursor that when passed to after: in a query will return the previous page of results."
-    )]
-    pub start_cursor: Option<CursorType>,
-
-    /// An opaque cursor that when passed to after: in a query will return the following page of
-    /// results.
-    #[graphql(
-        description = "An opaque cursor that when passed to after: in a query will return the following page of results."
-    )]
-    pub end_cursor: Option<CursorType>,
-}
 
 /// Represents a common Relay pagination request pattern. You'd usually build this from the arguments
 /// into the query resolver, and can then pass that into service calls etc.

--- a/juniper_relay_helpers/src/pagination.rs
+++ b/juniper_relay_helpers/src/pagination.rs
@@ -1,33 +1,129 @@
-use crate::{Cursor};
-use juniper::{GraphQLObject};
+use crate::{Cursor, CursorBase};
+use juniper::{
+    ArcStr, Arguments, BoxFuture, ExecutionResult, Executor, GraphQLType, GraphQLValue,
+    GraphQLValueAsync, ScalarValue,
+    executor::Registry,
+    macros::reflect::{BaseSubTypes, BaseType, WrappedType},
+    marker::IsOutputType,
+    meta::{Field, MetaType},
+};
 
 /// Represents the Relay spec pagination object
 /// <https://relay.dev/docs/guides/graphql-server-specification/>
 ///
-#[derive(Debug, GraphQLObject, Eq, PartialEq, Clone)]
-#[graphql(description = "Pagination information")]
-pub struct PageInfo<CursorType> where CursorType: Cursor {
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct PageInfo<CursorType> {
     /// Indicates whether there is a page following this current one
-    #[graphql(description = "Indicates whether there is a page following this current one")]
     pub has_next_page: bool,
 
     /// Indicates whether there is a page preceding this one
-    #[graphql(description = "Indicates whether there is a page preceding this one")]
     pub has_prev_page: bool,
 
-    /// An opaque cursor that when passed to after: in a query will return the previous page of
-    /// results.
-    #[graphql(
-        description = "An opaque cursor that when passed to after: in a query will return the previous page of results."
-    )]
+    /// An opaque cursor that when passed to after: in a query will return the previous page of results.
     pub start_cursor: Option<CursorType>,
 
-    /// An opaque cursor that when passed to after: in a query will return the following page of
-    /// results.
-    #[graphql(
-        description = "An opaque cursor that when passed to after: in a query will return the following page of results."
-    )]
+    /// An opaque cursor that when passed to after: in a query will return the following page of results.
     pub end_cursor: Option<CursorType>,
+}
+
+// --- Reflection traits ---
+
+impl<S: ScalarValue, CursorType> BaseType<S> for PageInfo<CursorType> {
+    const NAME: juniper::macros::reflect::Type = "PageInfo";
+}
+
+impl<S: ScalarValue, CursorType> WrappedType<S> for PageInfo<CursorType> {
+    const VALUE: juniper::macros::reflect::WrappedValue = 1;
+}
+
+impl<S: ScalarValue, CursorType> BaseSubTypes<S> for PageInfo<CursorType> {
+    const NAMES: juniper::macros::reflect::Types = &[<Self as BaseType<S>>::NAME];
+}
+
+// --- GraphQL output traits ---
+
+impl<S, CursorType> IsOutputType<S> for PageInfo<CursorType>
+where
+    S: ScalarValue + Send + Sync,
+    CursorType: Cursor<S>,
+{
+}
+
+impl<S, CursorType> GraphQLType<S> for PageInfo<CursorType>
+where
+    S: ScalarValue + Send + Sync,
+    CursorType: Cursor<S>,
+{
+    fn name(_: &()) -> Option<ArcStr> {
+        Some(juniper::arcstr::literal!("PageInfo"))
+    }
+
+    fn meta(info: &(), registry: &mut Registry<S>) -> MetaType<S> {
+        let fields: &[Field<S>] = &[
+            registry
+                .field::<bool>("hasNextPage", info)
+                .description("Indicates whether there is a page following this current one"),
+            registry
+                .field::<bool>("hasPrevPage", info)
+                .description("Indicates whether there is a page preceding this one"),
+            registry
+                .field::<Option<CursorType>>("startCursor", info)
+                .description("An opaque cursor; pass to `after:` to get the previous page."),
+            registry
+                .field::<Option<CursorType>>("endCursor", info)
+                .description("An opaque cursor; pass to `after:` to get the next page."),
+        ];
+        registry
+            .build_object_type::<Self>(info, fields)
+            .description("Pagination information")
+            .into_meta()
+    }
+}
+
+impl<S, CursorType> GraphQLValue<S> for PageInfo<CursorType>
+where
+    S: ScalarValue + Send + Sync,
+    CursorType: Cursor<S>,
+{
+    type TypeInfo = ();
+    type Context = ();
+
+    fn type_name(&self, _: &()) -> Option<ArcStr> {
+        Some(juniper::arcstr::literal!("PageInfo"))
+    }
+
+    fn resolve_field(
+        &self,
+        info: &(),
+        field_name: &str,
+        _: &Arguments<S>,
+        executor: &Executor<(), S>,
+    ) -> ExecutionResult<S> {
+        match field_name {
+            "hasNextPage" => executor.resolve(info, &self.has_next_page),
+            "hasPrevPage" => executor.resolve(info, &self.has_prev_page),
+            "startCursor" => executor.resolve(info, &self.start_cursor),
+            "endCursor" => executor.resolve(info, &self.end_cursor),
+            _ => panic!("Field '{}' not found on type 'PageInfo'", field_name),
+        }
+    }
+}
+
+impl<S, CursorType> GraphQLValueAsync<S> for PageInfo<CursorType>
+where
+    S: ScalarValue + Send + Sync,
+    CursorType: Cursor<S> + Sync,
+    Self: Sync,
+{
+    fn resolve_field_async<'a>(
+        &'a self,
+        info: &'a (),
+        field_name: &'a str,
+        args: &'a Arguments<S>,
+        executor: &'a Executor<(), S>,
+    ) -> BoxFuture<'a, ExecutionResult<S>> {
+        Box::pin(async move { self.resolve_field(info, field_name, args, executor) })
+    }
 }
 
 /// Represents a common Relay pagination request pattern. You'd usually build this from the arguments
@@ -47,7 +143,7 @@ pub struct PageInfo<CursorType> where CursorType: Cursor {
 /// This struct can be used to represent the first and after arguments.
 ///
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct PageRequest<CursorType> where CursorType: Cursor {
+pub struct PageRequest<CursorType> where CursorType: CursorBase {
     /// The number of items to return.
     pub first: Option<i32>,
 
@@ -58,7 +154,7 @@ pub struct PageRequest<CursorType> where CursorType: Cursor {
     pub after: Option<CursorType>,
 }
 
-impl<CursorT> PageRequest<CursorT> where CursorT: Cursor {
+impl<CursorT> PageRequest<CursorT> where CursorT: CursorBase {
     /// Helper method to build from the component parts from a query resolver
     pub fn new(first: Option<i32>, after: Option<CursorT>, before: Option<CursorT>) -> Self {
         PageRequest {

--- a/juniper_relay_helpers/src/pagination.rs
+++ b/juniper_relay_helpers/src/pagination.rs
@@ -1,129 +1,33 @@
-use crate::{Cursor, CursorBase};
-use juniper::{
-    ArcStr, Arguments, BoxFuture, ExecutionResult, Executor, GraphQLType, GraphQLValue,
-    GraphQLValueAsync, ScalarValue,
-    executor::Registry,
-    macros::reflect::{BaseSubTypes, BaseType, WrappedType},
-    marker::IsOutputType,
-    meta::{Field, MetaType},
-};
+use crate::{Cursor};
+use juniper::{GraphQLObject};
 
 /// Represents the Relay spec pagination object
 /// <https://relay.dev/docs/guides/graphql-server-specification/>
 ///
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct PageInfo<CursorType> {
+#[derive(Debug, GraphQLObject, Eq, PartialEq, Clone)]
+#[graphql(description = "Pagination information")]
+pub struct PageInfo<CursorType> where CursorType: Cursor {
     /// Indicates whether there is a page following this current one
+    #[graphql(description = "Indicates whether there is a page following this current one")]
     pub has_next_page: bool,
 
     /// Indicates whether there is a page preceding this one
+    #[graphql(description = "Indicates whether there is a page preceding this one")]
     pub has_prev_page: bool,
 
-    /// An opaque cursor that when passed to after: in a query will return the previous page of results.
+    /// An opaque cursor that when passed to after: in a query will return the previous page of
+    /// results.
+    #[graphql(
+        description = "An opaque cursor that when passed to after: in a query will return the previous page of results."
+    )]
     pub start_cursor: Option<CursorType>,
 
-    /// An opaque cursor that when passed to after: in a query will return the following page of results.
+    /// An opaque cursor that when passed to after: in a query will return the following page of
+    /// results.
+    #[graphql(
+        description = "An opaque cursor that when passed to after: in a query will return the following page of results."
+    )]
     pub end_cursor: Option<CursorType>,
-}
-
-// --- Reflection traits ---
-
-impl<S: ScalarValue, CursorType> BaseType<S> for PageInfo<CursorType> {
-    const NAME: juniper::macros::reflect::Type = "PageInfo";
-}
-
-impl<S: ScalarValue, CursorType> WrappedType<S> for PageInfo<CursorType> {
-    const VALUE: juniper::macros::reflect::WrappedValue = 1;
-}
-
-impl<S: ScalarValue, CursorType> BaseSubTypes<S> for PageInfo<CursorType> {
-    const NAMES: juniper::macros::reflect::Types = &[<Self as BaseType<S>>::NAME];
-}
-
-// --- GraphQL output traits ---
-
-impl<S, CursorType> IsOutputType<S> for PageInfo<CursorType>
-where
-    S: ScalarValue + Send + Sync,
-    CursorType: Cursor<S>,
-{
-}
-
-impl<S, CursorType> GraphQLType<S> for PageInfo<CursorType>
-where
-    S: ScalarValue + Send + Sync,
-    CursorType: Cursor<S>,
-{
-    fn name(_: &()) -> Option<ArcStr> {
-        Some(juniper::arcstr::literal!("PageInfo"))
-    }
-
-    fn meta(info: &(), registry: &mut Registry<S>) -> MetaType<S> {
-        let fields: &[Field<S>] = &[
-            registry
-                .field::<bool>("hasNextPage", info)
-                .description("Indicates whether there is a page following this current one"),
-            registry
-                .field::<bool>("hasPrevPage", info)
-                .description("Indicates whether there is a page preceding this one"),
-            registry
-                .field::<Option<CursorType>>("startCursor", info)
-                .description("An opaque cursor; pass to `after:` to get the previous page."),
-            registry
-                .field::<Option<CursorType>>("endCursor", info)
-                .description("An opaque cursor; pass to `after:` to get the next page."),
-        ];
-        registry
-            .build_object_type::<Self>(info, fields)
-            .description("Pagination information")
-            .into_meta()
-    }
-}
-
-impl<S, CursorType> GraphQLValue<S> for PageInfo<CursorType>
-where
-    S: ScalarValue + Send + Sync,
-    CursorType: Cursor<S>,
-{
-    type TypeInfo = ();
-    type Context = ();
-
-    fn type_name(&self, _: &()) -> Option<ArcStr> {
-        Some(juniper::arcstr::literal!("PageInfo"))
-    }
-
-    fn resolve_field(
-        &self,
-        info: &(),
-        field_name: &str,
-        _: &Arguments<S>,
-        executor: &Executor<(), S>,
-    ) -> ExecutionResult<S> {
-        match field_name {
-            "hasNextPage" => executor.resolve(info, &self.has_next_page),
-            "hasPrevPage" => executor.resolve(info, &self.has_prev_page),
-            "startCursor" => executor.resolve(info, &self.start_cursor),
-            "endCursor" => executor.resolve(info, &self.end_cursor),
-            _ => panic!("Field '{}' not found on type 'PageInfo'", field_name),
-        }
-    }
-}
-
-impl<S, CursorType> GraphQLValueAsync<S> for PageInfo<CursorType>
-where
-    S: ScalarValue + Send + Sync,
-    CursorType: Cursor<S> + Sync,
-    Self: Sync,
-{
-    fn resolve_field_async<'a>(
-        &'a self,
-        info: &'a (),
-        field_name: &'a str,
-        args: &'a Arguments<S>,
-        executor: &'a Executor<(), S>,
-    ) -> BoxFuture<'a, ExecutionResult<S>> {
-        Box::pin(async move { self.resolve_field(info, field_name, args, executor) })
-    }
 }
 
 /// Represents a common Relay pagination request pattern. You'd usually build this from the arguments
@@ -143,7 +47,7 @@ where
 /// This struct can be used to represent the first and after arguments.
 ///
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct PageRequest<CursorType> where CursorType: CursorBase {
+pub struct PageRequest<CursorType> where CursorType: Cursor {
     /// The number of items to return.
     pub first: Option<i32>,
 
@@ -154,7 +58,7 @@ pub struct PageRequest<CursorType> where CursorType: CursorBase {
     pub after: Option<CursorType>,
 }
 
-impl<CursorT> PageRequest<CursorT> where CursorT: CursorBase {
+impl<CursorT> PageRequest<CursorT> where CursorT: Cursor {
     /// Helper method to build from the component parts from a query resolver
     pub fn new(first: Option<i32>, after: Option<CursorT>, before: Option<CursorT>) -> Self {
         PageRequest {

--- a/juniper_relay_helpers/src/pagination.rs
+++ b/juniper_relay_helpers/src/pagination.rs
@@ -1,13 +1,12 @@
-use crate::cursor_errors::CursorError;
-use crate::{Cursor, cursor_from_encoded_string};
-use juniper::GraphQLObject;
+use crate::{Cursor};
+use juniper::{GraphQLObject};
 
 /// Represents the Relay spec pagination object
 /// <https://relay.dev/docs/guides/graphql-server-specification/>
 ///
 #[derive(Debug, GraphQLObject, Eq, PartialEq, Clone)]
 #[graphql(description = "Pagination information")]
-pub struct PageInfo {
+pub struct PageInfo<CursorType> where CursorType: Cursor {
     /// Indicates whether there is a page following this current one
     #[graphql(description = "Indicates whether there is a page following this current one")]
     pub has_next_page: bool,
@@ -21,14 +20,14 @@ pub struct PageInfo {
     #[graphql(
         description = "An opaque cursor that when passed to after: in a query will return the previous page of results."
     )]
-    pub start_cursor: Option<String>,
+    pub start_cursor: Option<CursorType>,
 
     /// An opaque cursor that when passed to after: in a query will return the following page of
     /// results.
     #[graphql(
         description = "An opaque cursor that when passed to after: in a query will return the following page of results."
     )]
-    pub end_cursor: Option<String>,
+    pub end_cursor: Option<CursorType>,
 }
 
 /// Represents a common Relay pagination request pattern. You'd usually build this from the arguments
@@ -45,69 +44,35 @@ pub struct PageInfo {
 ///  }
 /// ```
 ///
-/// This struct can be used to represent the first and after arguments. It is also a GraphQLObject itself,
-/// which means it can be used in the schema directly.
+/// This struct can be used to represent the first and after arguments.
 ///
-#[derive(Debug, GraphQLObject, Eq, PartialEq, Clone)]
-#[graphql(description = "Page request")]
-pub struct PageRequest {
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct PageRequest<CursorType> where CursorType: Cursor {
     /// The number of items to return.
-    #[graphql(description = "The number of items to return.")]
     pub first: Option<i32>,
 
+    /// A cursor to use as the pointer to use as the end of the page
+    pub before: Option<CursorType>,
+
     /// A cursor to use as the pointer to the start of the page.
-    #[graphql(description = "A cursor to use as the pointer to the start of the page.")]
-    pub after: Option<String>,
+    pub after: Option<CursorType>,
 }
 
-impl PageRequest {
+impl<CursorT> PageRequest<CursorT> where CursorT: Cursor {
     /// Helper method to build from the component parts from a query resolver
-    pub fn new(first: Option<i32>, after: Option<impl Cursor>) -> Self {
+    pub fn new(first: Option<i32>, after: Option<CursorT>, before: Option<CursorT>) -> Self {
         PageRequest {
             first,
-            after: after.map(|after| after.to_encoded_string()),
+            before,
+            after,
         }
     }
 
-    /// Parses the `after` portion of the PageRequest into the appropriate cursor type.
-    /// Will return `None` if the `Option` is empty, and returns wrapped in a `Result` in case the
-    /// decoding of the cursor fails.
-    pub fn parsed_cursor<T>(&self) -> Result<Option<T>, CursorError>
-    where
-        T: Cursor<CursorType = T>,
-    {
-        if self.after.is_none() {
-            return Ok(None);
+    /// Checks after, and then before, to return the current cursor we're working with.
+    pub fn current_cursor(&self) -> Option<CursorT> {
+        match &self.after {
+            Some(after) => Some(after.clone()),
+            None => self.before.clone(),
         }
-        let decoded_cursor = cursor_from_encoded_string(self.after.as_ref().unwrap())?;
-        Ok(Some(decoded_cursor))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{OffsetCursor, PageRequest, StringCursor};
-
-    #[test]
-    fn test_new() {
-        let pr = PageRequest::new(
-            Some(10),
-            Some(StringCursor::new("some-string-cursor".to_string())),
-        );
-        assert_eq!(pr.first, Some(10));
-        assert_eq!(
-            pr.after,
-            Some("c3RyaW5nfHxzb21lLXN0cmluZy1jdXJzb3I=".to_string())
-        );
-    }
-
-    #[test]
-    fn test_decoding_cursor_from_page_request() {
-        let request = PageRequest {
-            first: Some(10),
-            after: Some("b2Zmc2V0fHwx".to_string()),
-        };
-        let decoded_cursor = request.parsed_cursor::<OffsetCursor>().unwrap();
-        assert_eq!(decoded_cursor.unwrap().offset, 1);
     }
 }

--- a/juniper_relay_helpers/src/pagination_metadata.rs
+++ b/juniper_relay_helpers/src/pagination_metadata.rs
@@ -1,8 +1,8 @@
-use crate::{Cursor, PageRequest};
+use crate::{CursorBase, PageRequest};
 
 /// Struct that holds metadata about the response that can be used in the CursorProvider
 #[derive(Debug, Clone)]
-pub struct PaginationMetadata<CursorType> where CursorType: Cursor {
+pub struct PaginationMetadata<CursorType> where CursorType: CursorBase {
     /// The total number of items in the result set:
     pub total_count: Option<i32>,
 

--- a/juniper_relay_helpers/src/pagination_metadata.rs
+++ b/juniper_relay_helpers/src/pagination_metadata.rs
@@ -1,8 +1,8 @@
-use crate::{CursorBase, PageRequest};
+use crate::{Cursor, PageRequest};
 
 /// Struct that holds metadata about the response that can be used in the CursorProvider
 #[derive(Debug, Clone)]
-pub struct PaginationMetadata<CursorType> where CursorType: CursorBase {
+pub struct PaginationMetadata<CursorType> where CursorType: Cursor {
     /// The total number of items in the result set:
     pub total_count: Option<i32>,
 

--- a/juniper_relay_helpers/src/pagination_metadata.rs
+++ b/juniper_relay_helpers/src/pagination_metadata.rs
@@ -1,11 +1,11 @@
-use crate::PageRequest;
+use crate::{Cursor, PageRequest};
 
 /// Struct that holds metadata about the response that can be used in the CursorProvider
 #[derive(Debug, Clone)]
-pub struct PaginationMetadata {
+pub struct PaginationMetadata<CursorType> where CursorType: Cursor {
     /// The total number of items in the result set:
     pub total_count: Option<i32>,
 
     /// The current PageInfo, if any:
-    pub page_request: Option<PageRequest>,
+    pub page_request: Option<PageRequest<CursorType>>,
 }

--- a/juniper_relay_helpers_codegen/src/lib.rs
+++ b/juniper_relay_helpers_codegen/src/lib.rs
@@ -31,10 +31,10 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
             if let syn::Expr::Path(p) = &mnv.value { Some(p.path.clone()) } else { None }
         });
 
-    let cursor_type: Option<&Ident> = if let Some(cursor_path) = &cursor_attr {
-        cursor_path.get_ident()
+    let cursor_type = if let Some(cursor_path) = &cursor_attr {
+        quote! { #cursor_path }
     } else {
-        None
+        quote! { juniper_relay_helpers::StringCursor }
     };
 
     let out = match input.data {
@@ -54,37 +54,37 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 Span::mixed_site(),
             );
 
-            let default_cursor_type = Ident::new("StringCursor", Span::mixed_site());
-            let connection_cursor_type = cursor_type.unwrap_or(&default_cursor_type);
-
             let struct_name = input.ident;
 
             quote! {
-                use juniper_relay_helpers::StringCursor;
-
                 #[derive(juniper::GraphQLObject, Clone)]
                 #[graphql(
                     name = #connection_gql_name,
-                    description = #connection_gql_desc
+                    description = #connection_gql_desc,
+                    scalar = S: juniper::ScalarValue + Send + Sync
                     #context_clause
                 )]
+                #[automatically_derived]
                 pub struct #connection_name {
                     pub count: Option<i32>,
                     pub edges: Vec<#edge_name>,
-                    pub page_info: juniper_relay_helpers::PageInfo<#connection_cursor_type>,
+                    pub page_info: juniper_relay_helpers::PageInfo<#cursor_type>,
                 }
 
+                #[automatically_derived]
                 use juniper_relay_helpers::RelayEdge as #edge_trait_name;
+
+                #[automatically_derived]
                 impl juniper_relay_helpers::RelayConnection for #connection_name {
                     type EdgeType = #edge_name;
                     type NodeType = #struct_name;
-                    type CursorType = #connection_cursor_type;
+                    type CursorType = #cursor_type;
 
                     fn new(
                         nodes: &[#struct_name],
                         total_items: Option<i32>,
-                        cursor_provider: impl juniper_relay_helpers::CursorProvider<Self::NodeType>,
-                        page_request: Option<juniper_relay_helpers::PageRequest>
+                        cursor_provider: impl juniper_relay_helpers::CursorProvider<Self::NodeType, CursorType = #cursor_type>,
+                        page_request: Option<juniper_relay_helpers::PageRequest<#cursor_type>>
                     ) -> Self {
                         let metadata = juniper_relay_helpers::PaginationMetadata {
                             total_count: total_items,
@@ -106,19 +106,22 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 #[derive(juniper::GraphQLObject, Clone)]
                 #[graphql(
                     name = #edge_gql_name,
-                    description = #edge_gql_desc
+                    description = #edge_gql_desc,
+                    scalar = S: juniper::ScalarValue + Send + Sync
                     #context_clause
                 )]
+                #[automatically_derived]
                 pub struct #edge_name {
                     pub node: #struct_name,
-                    pub cursor: Option<#connection_cursor_type>,
+                    pub cursor: Option<#cursor_type>,
                 }
 
+                #[automatically_derived]
                 impl juniper_relay_helpers::RelayEdge for #edge_name {
                     type NodeType = #struct_name;
-                    type CursorType = #connection_cursor_type;
+                    type CursorType = #cursor_type;
 
-                    fn new(node: Self::NodeType, cursor: #connection_cursor_type) -> Self {
+                    fn new(node: Self::NodeType, cursor: #cursor_type) -> Self {
                         Self {
                             node: node,
                             cursor: Some(cursor),

--- a/juniper_relay_helpers_codegen/src/lib.rs
+++ b/juniper_relay_helpers_codegen/src/lib.rs
@@ -8,13 +8,14 @@ use syn::{Data, DeriveInput, parse_macro_input};
 pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    let relay_attr = input.attrs.iter()
+    let relay_attrs: Option<syn::punctuated::Punctuated<syn::MetaNameValue, syn::Token![,]>> = input.attrs.iter()
         .find(|a| a.path().is_ident("relay"))
-        .and_then(|a| a.parse_args::<syn::MetaNameValue>().ok());
+        .and_then(|a| a.parse_args_with(
+            syn::punctuated::Punctuated::<syn::MetaNameValue, syn::Token![,]>::parse_terminated
+        ).ok());
 
-    let context_attr = relay_attr
-        .clone()
-        .filter(|mnv| mnv.path.is_ident("context"))
+    let context_attr = relay_attrs.as_ref()
+        .and_then(|attrs| attrs.iter().find(|mnv| mnv.path.is_ident("context")))
         .and_then(|mnv| {
             if let syn::Expr::Path(p) = &mnv.value { Some(p.path.clone()) } else { None }
         });
@@ -25,16 +26,16 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
         quote! {}
     };
 
-    let cursor_attr = relay_attr
-        .filter(|mnv| mnv.path.is_ident("cursor"))
+    let cursor_attr = relay_attrs
+        .and_then(|attrs| attrs.into_iter().find(|mnv| mnv.path.is_ident("cursor")))
         .and_then(|mnv| {
-            if let syn::Expr::Path(p) = &mnv.value { Some(p.path.clone()) } else { None }
+            if let syn::Expr::Path(p) = mnv.value { Some(p.path) } else { None }
         });
 
-    let cursor_type: Option<&Ident> = if let Some(cursor_path) = &cursor_attr {
-        cursor_path.get_ident()
+    let cursor_type = if let Some(cursor_path) = &cursor_attr {
+        quote! { #cursor_path }
     } else {
-        None
+        quote! { juniper_relay_helpers::StringCursor }
     };
 
     let out = match input.data {
@@ -54,14 +55,13 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 Span::mixed_site(),
             );
 
-            let default_cursor_type = Ident::new("StringCursor", Span::mixed_site());
-            let connection_cursor_type = cursor_type.unwrap_or(&default_cursor_type);
+            let page_info_gql_name = format!("{}ConnectionPageInfo", input.ident);
+            let page_info_gql_desc = format!("PageInfo type for {}.", input.ident);
+            let page_info_name = Ident::new(&format!("{}RelayConnectionPageInfo", input.ident), Span::mixed_site());
 
             let struct_name = input.ident;
 
             quote! {
-                use juniper_relay_helpers::StringCursor;
-
                 #[derive(juniper::GraphQLObject, Clone)]
                 #[graphql(
                     name = #connection_gql_name,
@@ -71,22 +71,25 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 pub struct #connection_name {
                     pub count: Option<i32>,
                     pub edges: Vec<#edge_name>,
-                    pub page_info: juniper_relay_helpers::PageInfo<#connection_cursor_type>,
+                    pub page_info: #page_info_name,
                 }
 
                 use juniper_relay_helpers::RelayEdge as #edge_trait_name;
                 impl juniper_relay_helpers::RelayConnection for #connection_name {
                     type EdgeType = #edge_name;
                     type NodeType = #struct_name;
-                    type CursorType = #connection_cursor_type;
+                    type CursorType = #cursor_type;
 
-                    fn new(
+                    fn new<ProviderT>(
                         nodes: &[#struct_name],
                         total_items: Option<i32>,
-                        cursor_provider: impl juniper_relay_helpers::CursorProvider<Self::NodeType>,
-                        page_request: Option<juniper_relay_helpers::PageRequest>
-                    ) -> Self {
-                        let metadata = juniper_relay_helpers::PaginationMetadata {
+                        cursor_provider: ProviderT,
+                        page_request: Option<juniper_relay_helpers::PageRequest<#cursor_type>>,
+                    ) -> Self
+                    where
+                        ProviderT: juniper_relay_helpers::CursorProvider<Self::NodeType, CursorType = #cursor_type>
+                    {
+                        let metadata = juniper_relay_helpers::PaginationMetadata::<#cursor_type> {
                             total_count: total_items,
                             page_request
                         };
@@ -111,17 +114,52 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 )]
                 pub struct #edge_name {
                     pub node: #struct_name,
-                    pub cursor: Option<#connection_cursor_type>,
+                    pub cursor: Option<#cursor_type>,
                 }
 
                 impl juniper_relay_helpers::RelayEdge for #edge_name {
                     type NodeType = #struct_name;
-                    type CursorType = #connection_cursor_type;
+                    type CursorType = #cursor_type;
 
-                    fn new(node: Self::NodeType, cursor: #connection_cursor_type) -> Self {
+                    fn new(node: Self::NodeType, cursor: #cursor_type) -> Self {
                         Self {
                             node: node,
                             cursor: Some(cursor),
+                        }
+                    }
+                }
+
+                #[derive(juniper::GraphQLObject, Clone)]
+                #[graphql(
+                    name = #page_info_gql_name,
+                    description = #page_info_gql_desc
+                    #context_clause
+                )]
+                pub struct #page_info_name {
+                    #[graphql(description = "Indicates whether there is a page following this current one")]
+                    pub has_next_page: bool,
+
+                    #[graphql(description = "Indicates whether there is a page preceding this one")]
+                    pub has_prev_page: bool,
+
+                    #[graphql(
+                        description = "An opaque cursor that when passed to before: in a query will return the previous page of results."
+                    )]
+                    pub start_cursor: Option<#cursor_type>,
+
+                    #[graphql(
+                        description = "An opaque cursor that when passed to after: in a query will return the following page of results."
+                    )]
+                    pub end_cursor: Option<#cursor_type>,
+                }
+
+                impl juniper_relay_helpers::PageInfoFactory<#cursor_type> for #page_info_name {
+                    fn new(has_prev_page: bool, has_next_page: bool, start_cursor: Option<#cursor_type>, end_cursor: Option<#cursor_type>) -> Self {
+                        Self {
+                            has_next_page,
+                            has_prev_page,
+                            start_cursor,
+                            end_cursor,
                         }
                     }
                 }

--- a/juniper_relay_helpers_codegen/src/lib.rs
+++ b/juniper_relay_helpers_codegen/src/lib.rs
@@ -31,10 +31,10 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
             if let syn::Expr::Path(p) = &mnv.value { Some(p.path.clone()) } else { None }
         });
 
-    let cursor_type = if let Some(cursor_path) = &cursor_attr {
-        quote! { #cursor_path }
+    let cursor_type: Option<&Ident> = if let Some(cursor_path) = &cursor_attr {
+        cursor_path.get_ident()
     } else {
-        quote! { juniper_relay_helpers::StringCursor }
+        None
     };
 
     let out = match input.data {
@@ -54,37 +54,37 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 Span::mixed_site(),
             );
 
+            let default_cursor_type = Ident::new("StringCursor", Span::mixed_site());
+            let connection_cursor_type = cursor_type.unwrap_or(&default_cursor_type);
+
             let struct_name = input.ident;
 
             quote! {
+                use juniper_relay_helpers::StringCursor;
+
                 #[derive(juniper::GraphQLObject, Clone)]
                 #[graphql(
                     name = #connection_gql_name,
-                    description = #connection_gql_desc,
-                    scalar = S: juniper::ScalarValue + Send + Sync
+                    description = #connection_gql_desc
                     #context_clause
                 )]
-                #[automatically_derived]
                 pub struct #connection_name {
                     pub count: Option<i32>,
                     pub edges: Vec<#edge_name>,
-                    pub page_info: juniper_relay_helpers::PageInfo<#cursor_type>,
+                    pub page_info: juniper_relay_helpers::PageInfo<#connection_cursor_type>,
                 }
 
-                #[automatically_derived]
                 use juniper_relay_helpers::RelayEdge as #edge_trait_name;
-
-                #[automatically_derived]
                 impl juniper_relay_helpers::RelayConnection for #connection_name {
                     type EdgeType = #edge_name;
                     type NodeType = #struct_name;
-                    type CursorType = #cursor_type;
+                    type CursorType = #connection_cursor_type;
 
                     fn new(
                         nodes: &[#struct_name],
                         total_items: Option<i32>,
-                        cursor_provider: impl juniper_relay_helpers::CursorProvider<Self::NodeType, CursorType = #cursor_type>,
-                        page_request: Option<juniper_relay_helpers::PageRequest<#cursor_type>>
+                        cursor_provider: impl juniper_relay_helpers::CursorProvider<Self::NodeType>,
+                        page_request: Option<juniper_relay_helpers::PageRequest>
                     ) -> Self {
                         let metadata = juniper_relay_helpers::PaginationMetadata {
                             total_count: total_items,
@@ -106,22 +106,19 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 #[derive(juniper::GraphQLObject, Clone)]
                 #[graphql(
                     name = #edge_gql_name,
-                    description = #edge_gql_desc,
-                    scalar = S: juniper::ScalarValue + Send + Sync
+                    description = #edge_gql_desc
                     #context_clause
                 )]
-                #[automatically_derived]
                 pub struct #edge_name {
                     pub node: #struct_name,
-                    pub cursor: Option<#cursor_type>,
+                    pub cursor: Option<#connection_cursor_type>,
                 }
 
-                #[automatically_derived]
                 impl juniper_relay_helpers::RelayEdge for #edge_name {
                     type NodeType = #struct_name;
-                    type CursorType = #cursor_type;
+                    type CursorType = #connection_cursor_type;
 
-                    fn new(node: Self::NodeType, cursor: #cursor_type) -> Self {
+                    fn new(node: Self::NodeType, cursor: #connection_cursor_type) -> Self {
                         Self {
                             node: node,
                             cursor: Some(cursor),

--- a/juniper_relay_helpers_codegen/src/lib.rs
+++ b/juniper_relay_helpers_codegen/src/lib.rs
@@ -8,9 +8,12 @@ use syn::{Data, DeriveInput, parse_macro_input};
 pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    let context_attr: Option<syn::Path> = input.attrs.iter()
+    let relay_attr = input.attrs.iter()
         .find(|a| a.path().is_ident("relay"))
-        .and_then(|a| a.parse_args::<syn::MetaNameValue>().ok())
+        .and_then(|a| a.parse_args::<syn::MetaNameValue>().ok());
+
+    let context_attr = relay_attr
+        .clone()
         .filter(|mnv| mnv.path.is_ident("context"))
         .and_then(|mnv| {
             if let syn::Expr::Path(p) = &mnv.value { Some(p.path.clone()) } else { None }
@@ -22,24 +25,43 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
         quote! {}
     };
 
+    let cursor_attr = relay_attr
+        .filter(|mnv| mnv.path.is_ident("cursor"))
+        .and_then(|mnv| {
+            if let syn::Expr::Path(p) = &mnv.value { Some(p.path.clone()) } else { None }
+        });
+
+    let cursor_type: Option<&Ident> = if let Some(cursor_path) = &cursor_attr {
+        cursor_path.get_ident()
+    } else {
+        None
+    };
+
     let out = match input.data {
         Data::Struct(_s) => {
             let connection_gql_name = format!("{}Connection", input.ident);
             let connection_gql_desc = format!("Connection type for {}.", input.ident);
-            let edge_gql_name = format!("{}Edge", input.ident);
-            let edge_gql_desc = format!("Edge type for {}.", input.ident);
             let connection_name = Ident::new(
                 &format!("{}RelayConnection", input.ident),
                 Span::mixed_site(),
             );
+
+            let edge_gql_name = format!("{}Edge", input.ident);
+            let edge_gql_desc = format!("Edge type for {}.", input.ident);
             let edge_name = Ident::new(&format!("{}RelayEdge", input.ident), Span::mixed_site());
             let edge_trait_name = Ident::new(
                 &format!("{}RelayEdgeTrait", input.ident),
                 Span::mixed_site(),
             );
+
+            let default_cursor_type = Ident::new("StringCursor", Span::mixed_site());
+            let connection_cursor_type = cursor_type.unwrap_or(&default_cursor_type);
+
             let struct_name = input.ident;
 
             quote! {
+                use juniper_relay_helpers::StringCursor;
+
                 #[derive(juniper::GraphQLObject, Clone)]
                 #[graphql(
                     name = #connection_gql_name,
@@ -49,13 +71,14 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 pub struct #connection_name {
                     pub count: Option<i32>,
                     pub edges: Vec<#edge_name>,
-                    pub page_info: juniper_relay_helpers::PageInfo,
+                    pub page_info: juniper_relay_helpers::PageInfo<#connection_cursor_type>,
                 }
 
                 use juniper_relay_helpers::RelayEdge as #edge_trait_name;
                 impl juniper_relay_helpers::RelayConnection for #connection_name {
                     type EdgeType = #edge_name;
                     type NodeType = #struct_name;
+                    type CursorType = #connection_cursor_type;
 
                     fn new(
                         nodes: &[#struct_name],
@@ -88,22 +111,17 @@ pub fn macro_relay_connection_node(input: TokenStream) -> TokenStream {
                 )]
                 pub struct #edge_name {
                     pub node: #struct_name,
-                    pub cursor: Option<String>,
+                    pub cursor: Option<#connection_cursor_type>,
                 }
 
                 impl juniper_relay_helpers::RelayEdge for #edge_name {
                     type NodeType = #struct_name;
-                    fn new(node: Self::NodeType, cursor: impl juniper_relay_helpers::Cursor) -> Self {
-                        Self {
-                            node: node,
-                            cursor: Some(cursor.to_encoded_string()),
-                        }
-                    }
+                    type CursorType = #connection_cursor_type;
 
-                    fn new_raw_cursor(node: Self::NodeType, cursor: Option<String>) -> Self {
+                    fn new(node: Self::NodeType, cursor: #connection_cursor_type) -> Self {
                         Self {
                             node: node,
-                            cursor: cursor,
+                            cursor: Some(cursor),
                         }
                     }
                 }

--- a/juniper_relay_helpers_test/schema.graphql
+++ b/juniper_relay_helpers_test/schema.graphql
@@ -1,0 +1,109 @@
+schema {
+  query: QueryRoot
+}
+
+"A simple offset-based cursor."
+scalar OffsetCursor
+
+"""
+  Built-in cursor type for when the cursor is just a string. Usually useful for things like
+  NoSQL systems that return something opaque to you.
+"""
+scalar StringCursor
+
+"""
+  [Universally Unique Identifier][0] (UUID).
+
+  [`UUID` scalar][1] compliant.
+
+  See also [`uuid::Uuid`][2] for details.
+
+  [0]: https://en.wikipedia.org/wiki/Universally_unique_identifier
+  [1]: https://graphql-scalars.dev/docs/scalars/uuid
+  [2]: https://docs.rs/uuid/*/uuid/struct.Uuid.html
+"""
+scalar UUID
+
+"GraphQL type for a character."
+type Character {
+  id: ID!
+  name: String!
+}
+
+"Connection type for Character."
+type CharacterConnection {
+  count: Int
+  edges: [CharacterEdge!]!
+  pageInfo: CharacterConnectionPageInfo!
+}
+
+"PageInfo type for Character."
+type CharacterConnectionPageInfo {
+  "Indicates whether there is a page following this current one"
+  hasNextPage: Boolean!
+  "Indicates whether there is a page preceding this one"
+  hasPrevPage: Boolean!
+  "An opaque cursor that when passed to before: in a query will return the previous page of results."
+  startCursor: OffsetCursor
+  "An opaque cursor that when passed to after: in a query will return the following page of results."
+  endCursor: OffsetCursor
+}
+
+"Edge type for Character."
+type CharacterEdge {
+  node: Character!
+  cursor: OffsetCursor
+}
+
+"GraphQL type for a character."
+type Location {
+  id: ID!
+  name: String!
+}
+
+"Connection type for Location."
+type LocationConnection {
+  count: Int
+  edges: [LocationEdge!]!
+  pageInfo: LocationConnectionPageInfo!
+}
+
+"PageInfo type for Location."
+type LocationConnectionPageInfo {
+  "Indicates whether there is a page following this current one"
+  hasNextPage: Boolean!
+  "Indicates whether there is a page preceding this one"
+  hasPrevPage: Boolean!
+  "An opaque cursor that when passed to before: in a query will return the previous page of results."
+  startCursor: StringCursor
+  "An opaque cursor that when passed to after: in a query will return the following page of results."
+  endCursor: StringCursor
+}
+
+"Edge type for Location."
+type LocationEdge {
+  node: Location!
+  cursor: StringCursor
+}
+
+type MusicTrack {
+  id: UUID!
+  title: String!
+  locationsHeard: [Location!]!
+}
+
+type QueryRoot {
+  """
+    Queries for all characters in the "database"
+    This method shows how you can manually build up the resulting structs without using
+    cursor providers or any of the other fancy stuff.
+  """
+  characters: CharacterConnection!
+  """
+    Queries for all locations in the "database"
+    This method makes use of cursor providers and the shortcut methods to show how much you can
+    hand off to the library:
+  """
+  locations(first: Int, after: StringCursor): LocationConnection!
+  music: [MusicTrack!]!
+}

--- a/juniper_relay_helpers_test/src/generated_schema.rs
+++ b/juniper_relay_helpers_test/src/generated_schema.rs
@@ -2,7 +2,7 @@
 mod integration_tests {
     use googletest::prelude::*;
     use juniper::{EmptyMutation, EmptySubscription, FieldResult, GraphQLObject, RootNode};
-    use juniper_relay_helpers::{PageInfo, RelayConnection};
+    use juniper_relay_helpers::{RelayConnection, StringCursor};
 
     // ---- Define the types ----
 
@@ -36,10 +36,10 @@ mod integration_tests {
                         node: User {
                             name: "Sciel".to_owned(),
                         },
-                        cursor: Some("some-string".to_owned()),
+                        cursor: Some(StringCursor::new("some-string".to_string())),
                     },
                 ],
-                page_info: PageInfo {
+                page_info: UserRelayConnectionPageInfo {
                     start_cursor: None,
                     end_cursor: None,
                     has_prev_page: false,
@@ -52,7 +52,7 @@ mod integration_tests {
             Ok(PostRelayConnection {
                 count: Some(0),
                 edges: vec![],
-                page_info: PageInfo {
+                page_info: PostRelayConnectionPageInfo {
                     start_cursor: None,
                     end_cursor: None,
                     has_prev_page: false,
@@ -107,7 +107,7 @@ mod integration_tests {
         let schema_document = build_schema();
         let schema_sdl = schema_document.as_sdl();
 
-        assert_that!(schema_sdl, contains_substring("type PageInfo"));
-        assert_that!(schema_sdl, contains_substring("Pagination information"));
+        assert_that!(schema_sdl, contains_substring("type UserConnectionPageInfo"));
+        assert_that!(schema_sdl, contains_substring("type PostConnectionPageInfo"));
     }
 }

--- a/juniper_relay_helpers_test/src/generated_schema.rs
+++ b/juniper_relay_helpers_test/src/generated_schema.rs
@@ -20,7 +20,7 @@ mod integration_tests {
 
     struct QueryRoot;
 
-    #[juniper::graphql_object]
+    #[juniper::graphql_object()]
     impl QueryRoot {
         fn get_users() -> FieldResult<UserRelayConnection> {
             Ok(UserRelayConnection {

--- a/juniper_relay_helpers_test/src/generated_schema.rs
+++ b/juniper_relay_helpers_test/src/generated_schema.rs
@@ -20,7 +20,7 @@ mod integration_tests {
 
     struct QueryRoot;
 
-    #[juniper::graphql_object()]
+    #[juniper::graphql_object]
     impl QueryRoot {
         fn get_users() -> FieldResult<UserRelayConnection> {
             Ok(UserRelayConnection {

--- a/juniper_relay_helpers_test/src/main.rs
+++ b/juniper_relay_helpers_test/src/main.rs
@@ -6,6 +6,7 @@
 //! Application is also used for integration tests.
 //!
 
+use std::fs;
 use crate::schema::{QueryRoot, Schema, get_character_test_data, get_location_test_data, get_music_test_data};
 use crate::context::Context;
 use axum::Router;
@@ -36,6 +37,13 @@ fn build_app() -> Router {
         EmptyMutation::new(),
         EmptySubscription::new(),
     ));
+
+    // Write out the schema file so we can keep an eye on diffs:
+    let sdl = schema.as_sdl();
+    let output_path = format!("{}/schema.graphql", env!("CARGO_MANIFEST_DIR"));
+    if let Err(e) = fs::write(output_path, &sdl) {
+        eprintln!("Failed to write schema file: {}", e);
+    }
 
     // Build the app context:
     let ctx = AppContext {
@@ -268,7 +276,7 @@ mod integration_tests {
                                 "cursor": expect_json::string(),
                             })),
                         "pageInfo": expect_json::object().contains(json!({
-                            "hasNextPage": false,
+                            "hasNextPage": true,
                             "hasPrevPage": false
                         }))
                     }))

--- a/juniper_relay_helpers_test/src/schema/character.rs
+++ b/juniper_relay_helpers_test/src/schema/character.rs
@@ -1,5 +1,5 @@
 use juniper::GraphQLObject;
-use juniper_relay_helpers::{RelayConnection, RelayIdentifier};
+use juniper_relay_helpers::{RelayConnection, RelayIdentifier, OffsetCursor};
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -14,6 +14,7 @@ pub struct CharacterRow {
 
 /// GraphQL type for a character.
 #[derive(GraphQLObject, RelayConnection, Debug, Eq, PartialEq, Clone)]
+#[relay(cursor = OffsetCursor)]
 pub struct Character {
     pub id: RelayIdentifier<Uuid, EntityType>,
     pub name: String,

--- a/juniper_relay_helpers_test/src/schema/character.rs
+++ b/juniper_relay_helpers_test/src/schema/character.rs
@@ -1,5 +1,5 @@
 use juniper::GraphQLObject;
-use juniper_relay_helpers::{OffsetCursor, RelayConnection, RelayIdentifier};
+use juniper_relay_helpers::{RelayConnection, RelayIdentifier};
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -14,7 +14,6 @@ pub struct CharacterRow {
 
 /// GraphQL type for a character.
 #[derive(GraphQLObject, RelayConnection, Debug, Eq, PartialEq, Clone)]
-#[relay(cursor = OffsetCursor)]
 pub struct Character {
     pub id: RelayIdentifier<Uuid, EntityType>,
     pub name: String,

--- a/juniper_relay_helpers_test/src/schema/character.rs
+++ b/juniper_relay_helpers_test/src/schema/character.rs
@@ -1,5 +1,5 @@
 use juniper::GraphQLObject;
-use juniper_relay_helpers::{RelayConnection, RelayIdentifier};
+use juniper_relay_helpers::{OffsetCursor, RelayConnection, RelayIdentifier};
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -14,6 +14,7 @@ pub struct CharacterRow {
 
 /// GraphQL type for a character.
 #[derive(GraphQLObject, RelayConnection, Debug, Eq, PartialEq, Clone)]
+#[relay(cursor = OffsetCursor)]
 pub struct Character {
     pub id: RelayIdentifier<Uuid, EntityType>,
     pub name: String,

--- a/juniper_relay_helpers_test/src/schema/location.rs
+++ b/juniper_relay_helpers_test/src/schema/location.rs
@@ -1,5 +1,5 @@
 use juniper::GraphQLObject;
-use juniper_relay_helpers::{CursorByKey, RelayConnection, RelayIdentifier};
+use juniper_relay_helpers::{CursorByKey, RelayConnection, RelayIdentifier, StringCursor};
 
 use crate::schema::identifiers::EntityType;
 
@@ -12,6 +12,7 @@ pub struct LocationRow {
 
 /// GraphQL type for a character.
 #[derive(GraphQLObject, RelayConnection, Debug, Eq, PartialEq, Clone)]
+#[relay(cursor = StringCursor)]
 pub struct Location {
     pub id: RelayIdentifier<String, EntityType>,
     pub name: String,

--- a/juniper_relay_helpers_test/src/schema/location.rs
+++ b/juniper_relay_helpers_test/src/schema/location.rs
@@ -1,5 +1,5 @@
 use juniper::GraphQLObject;
-use juniper_relay_helpers::{CursorByKey, OffsetCursor, RelayConnection, RelayIdentifier};
+use juniper_relay_helpers::{CursorByKey, RelayConnection, RelayIdentifier};
 
 use crate::schema::identifiers::EntityType;
 
@@ -12,7 +12,6 @@ pub struct LocationRow {
 
 /// GraphQL type for a character.
 #[derive(GraphQLObject, RelayConnection, Debug, Eq, PartialEq, Clone)]
-#[relay(cursor = OffsetCursor)]
 pub struct Location {
     pub id: RelayIdentifier<String, EntityType>,
     pub name: String,

--- a/juniper_relay_helpers_test/src/schema/location.rs
+++ b/juniper_relay_helpers_test/src/schema/location.rs
@@ -1,5 +1,5 @@
 use juniper::GraphQLObject;
-use juniper_relay_helpers::{CursorByKey, RelayConnection, RelayIdentifier};
+use juniper_relay_helpers::{CursorByKey, OffsetCursor, RelayConnection, RelayIdentifier};
 
 use crate::schema::identifiers::EntityType;
 
@@ -12,6 +12,7 @@ pub struct LocationRow {
 
 /// GraphQL type for a character.
 #[derive(GraphQLObject, RelayConnection, Debug, Eq, PartialEq, Clone)]
+#[relay(cursor = OffsetCursor)]
 pub struct Location {
     pub id: RelayIdentifier<String, EntityType>,
     pub name: String,

--- a/juniper_relay_helpers_test/src/schema/mod.rs
+++ b/juniper_relay_helpers_test/src/schema/mod.rs
@@ -7,8 +7,8 @@ pub use crate::schema::location::{Location, LocationRelayConnection, LocationRow
 pub use crate::schema::music::{MusicRow, MusicTrack};
 use juniper::{EmptyMutation, EmptySubscription, FieldResult, RootNode};
 use juniper_relay_helpers::{
-    Cursor, CursorProvider, KeyedCursorProvider, OffsetCursor, OffsetCursorProvider, PageInfo,
-    PageRequest, PaginationMetadata, RelayConnection, RelayEdge, RelayIdentifier, StringCursor,
+    OffsetCursor, OffsetCursorProvider, PageInfo,
+    PageRequest, RelayConnection, RelayEdge, RelayIdentifier,
 };
 
 mod character;
@@ -25,7 +25,7 @@ pub use crate::schema::music::get_music_test_data;
 
 pub struct QueryRoot;
 
-#[juniper::graphql_object(context = Context)]
+#[juniper::graphql_object(context = Context, scalar = S: juniper::ScalarValue + Send + Sync)]
 impl QueryRoot {
     /// Queries for all characters in the "database"
     /// This method shows how you can manually build up the resulting structs without using
@@ -82,44 +82,26 @@ impl QueryRoot {
             &nodes,
             Some(ctx.locations.len() as i32),
             OffsetCursorProvider::new(),
-            Some(PageRequest::new(first, after)),
+            Some(PageRequest::new(first, after, None)),
         ))
     }
 
-    /// Queries for all locations in the "database"
-    /// This method makes use of the String cursor provider to show how you can use that one too!
-    async fn locations_string_cursor(
+    /// Queries for all locations using an offset cursor from a numeric page arg.
+    async fn locations_paged(
         first: Option<i32>,
-        after: Option<StringCursor>,
+        page: Option<i32>,
         ctx: &Context,
     ) -> FieldResult<LocationRelayConnection> {
+        let after = page.map(OffsetCursor::new);
         let mut nodes = ctx
             .locations
             .iter()
             .map(|row| Location::from(row.clone()))
             .collect::<Vec<Location>>();
 
-        let cp = KeyedCursorProvider;
-        let pr = PageRequest::new(first, after);
-
-        if let Some(after_cursor) = &pr.after {
-            // Find the starting item:
-            let idx = nodes.iter().position(|item| {
-                let sub_page =
-                    PageRequest::new(first, Some(StringCursor::new(after_cursor.clone())));
-                let pagination_metadata = PaginationMetadata {
-                    total_count: Some(ctx.locations.len() as i32),
-                    page_request: Some(sub_page),
-                };
-                let item_cursor = cp.get_cursor_for_item(&pagination_metadata, 0, item);
-                item_cursor.to_encoded_string().eq(after_cursor)
-            });
-
-            if let Some(idx) = idx {
-                nodes = nodes.split_off(idx + 1);
-            }
+        if let Some(ref c) = after {
+            nodes = nodes.split_off(c.offset as usize + 1);
         }
-
         if let Some(first) = first {
             nodes.truncate(first as usize);
         }
@@ -127,8 +109,8 @@ impl QueryRoot {
         Ok(LocationRelayConnection::new(
             &nodes,
             Some(ctx.locations.len() as i32),
-            KeyedCursorProvider,
-            Some(pr),
+            OffsetCursorProvider::new(),
+            Some(PageRequest::new(first, after, None)),
         ))
     }
 

--- a/juniper_relay_helpers_test/src/schema/mod.rs
+++ b/juniper_relay_helpers_test/src/schema/mod.rs
@@ -7,8 +7,8 @@ pub use crate::schema::location::{Location, LocationRelayConnection, LocationRow
 pub use crate::schema::music::{MusicRow, MusicTrack};
 use juniper::{EmptyMutation, EmptySubscription, FieldResult, RootNode};
 use juniper_relay_helpers::{
-    OffsetCursor, OffsetCursorProvider, PageInfo,
-    PageRequest, RelayConnection, RelayEdge, RelayIdentifier,
+    Cursor, CursorProvider, KeyedCursorProvider, OffsetCursor, OffsetCursorProvider, PageInfo,
+    PageRequest, PaginationMetadata, RelayConnection, RelayEdge, RelayIdentifier, StringCursor,
 };
 
 mod character;
@@ -25,7 +25,7 @@ pub use crate::schema::music::get_music_test_data;
 
 pub struct QueryRoot;
 
-#[juniper::graphql_object(context = Context, scalar = S: juniper::ScalarValue + Send + Sync)]
+#[juniper::graphql_object(context = Context)]
 impl QueryRoot {
     /// Queries for all characters in the "database"
     /// This method shows how you can manually build up the resulting structs without using
@@ -82,26 +82,44 @@ impl QueryRoot {
             &nodes,
             Some(ctx.locations.len() as i32),
             OffsetCursorProvider::new(),
-            Some(PageRequest::new(first, after, None)),
+            Some(PageRequest::new(first, after)),
         ))
     }
 
-    /// Queries for all locations using an offset cursor from a numeric page arg.
-    async fn locations_paged(
+    /// Queries for all locations in the "database"
+    /// This method makes use of the String cursor provider to show how you can use that one too!
+    async fn locations_string_cursor(
         first: Option<i32>,
-        page: Option<i32>,
+        after: Option<StringCursor>,
         ctx: &Context,
     ) -> FieldResult<LocationRelayConnection> {
-        let after = page.map(OffsetCursor::new);
         let mut nodes = ctx
             .locations
             .iter()
             .map(|row| Location::from(row.clone()))
             .collect::<Vec<Location>>();
 
-        if let Some(ref c) = after {
-            nodes = nodes.split_off(c.offset as usize + 1);
+        let cp = KeyedCursorProvider;
+        let pr = PageRequest::new(first, after);
+
+        if let Some(after_cursor) = &pr.after {
+            // Find the starting item:
+            let idx = nodes.iter().position(|item| {
+                let sub_page =
+                    PageRequest::new(first, Some(StringCursor::new(after_cursor.clone())));
+                let pagination_metadata = PaginationMetadata {
+                    total_count: Some(ctx.locations.len() as i32),
+                    page_request: Some(sub_page),
+                };
+                let item_cursor = cp.get_cursor_for_item(&pagination_metadata, 0, item);
+                item_cursor.to_encoded_string().eq(after_cursor)
+            });
+
+            if let Some(idx) = idx {
+                nodes = nodes.split_off(idx + 1);
+            }
         }
+
         if let Some(first) = first {
             nodes.truncate(first as usize);
         }
@@ -109,8 +127,8 @@ impl QueryRoot {
         Ok(LocationRelayConnection::new(
             &nodes,
             Some(ctx.locations.len() as i32),
-            OffsetCursorProvider::new(),
-            Some(PageRequest::new(first, after, None)),
+            KeyedCursorProvider,
+            Some(pr),
         ))
     }
 

--- a/juniper_relay_helpers_test/src/schema/mod.rs
+++ b/juniper_relay_helpers_test/src/schema/mod.rs
@@ -7,9 +7,10 @@ pub use crate::schema::location::{Location, LocationRelayConnection, LocationRow
 pub use crate::schema::music::{MusicRow, MusicTrack};
 use juniper::{EmptyMutation, EmptySubscription, FieldResult, RootNode};
 use juniper_relay_helpers::{
-    Cursor, CursorProvider, KeyedCursorProvider, OffsetCursor, OffsetCursorProvider, PageInfo,
+    CursorProvider, KeyedCursorProvider, OffsetCursor,
     PageRequest, PaginationMetadata, RelayConnection, RelayEdge, RelayIdentifier, StringCursor,
 };
+use crate::schema::character::CharacterRelayConnectionPageInfo;
 
 mod character;
 mod identifiers;
@@ -47,7 +48,7 @@ impl QueryRoot {
                     )
                 })
                 .collect(),
-            page_info: PageInfo {
+            page_info: CharacterRelayConnectionPageInfo {
                 has_next_page: false,
                 has_prev_page: false,
                 start_cursor: None,
@@ -61,35 +62,6 @@ impl QueryRoot {
     /// hand off to the library:
     async fn locations(
         first: Option<i32>,
-        after: Option<OffsetCursor>,
-        ctx: &Context,
-    ) -> FieldResult<LocationRelayConnection> {
-        let mut nodes = ctx
-            .locations
-            .iter()
-            .map(|row| Location::from(row.clone()))
-            .collect::<Vec<Location>>();
-
-        if let Some(after) = &after {
-            nodes = nodes.split_off(after.offset as usize + 1);
-        }
-
-        if let Some(first) = first {
-            nodes.truncate(first as usize);
-        }
-
-        Ok(LocationRelayConnection::new(
-            &nodes,
-            Some(ctx.locations.len() as i32),
-            OffsetCursorProvider::new(),
-            Some(PageRequest::new(first, after)),
-        ))
-    }
-
-    /// Queries for all locations in the "database"
-    /// This method makes use of the String cursor provider to show how you can use that one too!
-    async fn locations_string_cursor(
-        first: Option<i32>,
         after: Option<StringCursor>,
         ctx: &Context,
     ) -> FieldResult<LocationRelayConnection> {
@@ -100,19 +72,19 @@ impl QueryRoot {
             .collect::<Vec<Location>>();
 
         let cp = KeyedCursorProvider;
-        let pr = PageRequest::new(first, after);
+        let pr = PageRequest::new(first, after.clone(), None);
 
         if let Some(after_cursor) = &pr.after {
             // Find the starting item:
             let idx = nodes.iter().position(|item| {
                 let sub_page =
-                    PageRequest::new(first, Some(StringCursor::new(after_cursor.clone())));
+                    PageRequest::new(first, Some(after_cursor.clone()), None);
                 let pagination_metadata = PaginationMetadata {
                     total_count: Some(ctx.locations.len() as i32),
                     page_request: Some(sub_page),
                 };
                 let item_cursor = cp.get_cursor_for_item(&pagination_metadata, 0, item);
-                item_cursor.to_encoded_string().eq(after_cursor)
+                item_cursor.eq(after_cursor)
             });
 
             if let Some(idx) = idx {
@@ -128,7 +100,7 @@ impl QueryRoot {
             &nodes,
             Some(ctx.locations.len() as i32),
             KeyedCursorProvider,
-            Some(pr),
+            Some(PageRequest::new(first, after, None)),
         ))
     }
 

--- a/juniper_relay_helpers_test/src/schema/music.rs
+++ b/juniper_relay_helpers_test/src/schema/music.rs
@@ -1,6 +1,6 @@
 use juniper::graphql_object;
 use uuid::Uuid;
-use juniper_relay_helpers::RelayConnection;
+use juniper_relay_helpers::{RelayConnection, OffsetCursor};
 use crate::context::Context;
 use crate::schema::Location;
 
@@ -13,7 +13,7 @@ pub struct MusicRow {
 /// This is an example of a "complex" field resolver type, where there is a dedicated impl
 /// block for the field resolver, which also contains a context parameter.
 #[derive(Clone, Debug, RelayConnection, Eq, PartialEq)]
-#[relay(context = Context)]
+#[relay(context = Context, cursor = OffsetCursor)]
 pub struct MusicTrack {
     pub id: Uuid,
     pub title: String,


### PR DESCRIPTION
This is a very breaking change because it introduces a big schema change for you if you're using the library.