### PR TITLE
chore: release

### DIFF
--- a/juniper_relay_helpers/CHANGELOG.md
+++ b/juniper_relay_helpers/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers-v0.5.0...juniper_relay_helpers-v0.6.0) - 2026-06-29
+
+### Added
+
+- [**breaking**] strict typing of cursors in Connections and PageInfo ([#35](https://github.com/solution10/juniper-relay-helpers/pull/35))
+
+### Other
+
+- add Rustfmt with default settings + CI ([#37](https://github.com/solution10/juniper-relay-helpers/pull/37))
+
 ## [0.5.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers-v0.4.0...juniper_relay_helpers-v0.5.0) - 2026-06-29
 
 ### Added

--- a/juniper_relay_helpers/Cargo.toml
+++ b/juniper_relay_helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "juniper_relay_helpers"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "MIT"
 description = "Helper macros, structs and functions for working with Relay and Juniper"
@@ -16,7 +16,7 @@ keywords = ["relay", "juniper", "graphql", "server", "web"]
 
 [dependencies]
 
-juniper_relay_helpers_codegen = { path = "../juniper_relay_helpers_codegen", version = "0.5.0" }
+juniper_relay_helpers_codegen = { path = "../juniper_relay_helpers_codegen", version = "0.6.0" }
 juniper = { workspace = true }
 base64 = { workspace = true }
 uuid = {  workspace = true, features = ["v4"] }

--- a/juniper_relay_helpers_codegen/CHANGELOG.md
+++ b/juniper_relay_helpers_codegen/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers_codegen-v0.5.0...juniper_relay_helpers_codegen-v0.6.0) - 2026-06-29
+
+### Added
+
+- [**breaking**] strict typing of cursors in Connections and PageInfo ([#35](https://github.com/solution10/juniper-relay-helpers/pull/35))
+
+### Other
+
+- add Rustfmt with default settings + CI ([#37](https://github.com/solution10/juniper-relay-helpers/pull/37))
+
 ## [0.5.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers_codegen-v0.4.0...juniper_relay_helpers_codegen-v0.5.0) - 2026-06-29
 
 ### Added

--- a/juniper_relay_helpers_codegen/Cargo.toml
+++ b/juniper_relay_helpers_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "juniper_relay_helpers_codegen"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "MIT"
 description = "Derive macro crate for juniper_relay_helpers"


### PR DESCRIPTION



## 🤖 New release

* `juniper_relay_helpers_codegen`: 0.5.0 -> 0.6.0
* `juniper_relay_helpers`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `juniper_relay_helpers_test`: 0.1.6

### ⚠ `juniper_relay_helpers` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PageRequest.before in /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/page_request.rs:28

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  PageRequest::parsed_cursor, previously in file /tmp/.tmpWPoHg4/juniper_relay_helpers/src/pagination.rs:75

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  juniper_relay_helpers::PageRequest::new takes 2 parameters in /tmp/.tmpWPoHg4/juniper_relay_helpers/src/pagination.rs:65, but now takes 3 parameters in /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/page_request.rs:39

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct juniper_relay_helpers::PageInfo, previously in file /tmp/.tmpWPoHg4/juniper_relay_helpers/src/pagination.rs:10

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait juniper_relay_helpers::Cursor gained Clone in file /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/cursors/cursor.rs:30
  trait juniper_relay_helpers::Cursor gained FromInputValue in file /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/cursors/cursor.rs:30

--- failure trait_associated_type_added: non-sealed public trait added associated type without default value ---

Description:
A non-sealed trait has gained an associated type without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_associated_type_added.ron

Failed in:
  trait associated type juniper_relay_helpers::CursorProvider::CursorType in file /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/cursor_provider.rs:11
  trait associated type juniper_relay_helpers::RelayConnection::CursorType in file /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/connections.rs:13
  trait associated type juniper_relay_helpers::RelayEdge::CursorType in file /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/edges.rs:6

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method new_raw_cursor of trait RelayEdge, previously in file /tmp/.tmpWPoHg4/juniper_relay_helpers/src/edges.rs:11

--- failure trait_method_requires_different_generic_type_params: trait method now requires a different number of generic type parameters ---

Description:
A trait method now requires a different number of generic type parameters than it used to. Calls or implementations of this trait method using the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_requires_different_generic_type_params.ron

Failed in:
  CursorProvider::get_page_info (0 -> 1 generic types) in /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/cursor_provider.rs:26
  RelayConnection::new (0 -> 1 generic types) in /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/connections.rs:17

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait PaginationMetadata (0 -> 1 required generic types) in /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/pagination_metadata.rs:5
  trait PageRequest (0 -> 1 required generic types) in /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/page_request.rs:20

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct PaginationMetadata (0 -> 1 required generic types) in /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/pagination_metadata.rs:5
  Struct PageRequest (0 -> 1 required generic types) in /tmp/.tmpbnfkG4/juniper-relay-helpers/juniper_relay_helpers/src/page_request.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `juniper_relay_helpers_codegen`

<blockquote>

## [0.6.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers_codegen-v0.5.0...juniper_relay_helpers_codegen-v0.6.0) - 2026-06-29

### Added

- [**breaking**] strict typing of cursors in Connections and PageInfo ([#35](https://github.com/solution10/juniper-relay-helpers/pull/35))

### Other

- add Rustfmt with default settings + CI ([#37](https://github.com/solution10/juniper-relay-helpers/pull/37))
</blockquote>

## `juniper_relay_helpers`

<blockquote>

## [0.6.0](https://github.com/solution10/juniper-relay-helpers/compare/juniper_relay_helpers-v0.5.0...juniper_relay_helpers-v0.6.0) - 2026-06-29

### Added

- [**breaking**] strict typing of cursors in Connections and PageInfo ([#35](https://github.com/solution10/juniper-relay-helpers/pull/35))

### Other

- add Rustfmt with default settings + CI ([#37](https://github.com/solution10/juniper-relay-helpers/pull/37))
</blockquote>

## `juniper_relay_helpers_test`

<blockquote>

## [0.1.6](https://github.com/solution10/juniper-relay-helpers/releases/tag/juniper_relay_helpers_test-v0.1.6) - 2026-06-27

### Added

- add context marker to RelayConnection ([#26](https://github.com/solution10/juniper-relay-helpers/pull/26))
- adding more documentation ([#2](https://github.com/solution10/juniper-relay-helpers/pull/2))
- cursor providers ([#1](https://github.com/solution10/juniper-relay-helpers/pull/1))
- make cursors scalar types

### Fixed

- [**breaking**] not exposing `CursorByKey` trait correctly and adjusting cursor fmt ([#21](https://github.com/solution10/juniper-relay-helpers/pull/21))

### Other

- release master ([#24](https://github.com/solution10/juniper-relay-helpers/pull/24))
- release master ([#22](https://github.com/solution10/juniper-relay-helpers/pull/22))
- release master ([#20](https://github.com/solution10/juniper-relay-helpers/pull/20))
- release master ([#17](https://github.com/solution10/juniper-relay-helpers/pull/17))
- reformat ([#18](https://github.com/solution10/juniper-relay-helpers/pull/18))
- release master ([#15](https://github.com/solution10/juniper-relay-helpers/pull/15))
- release master ([#14](https://github.com/solution10/juniper-relay-helpers/pull/14))
- release master ([#6](https://github.com/solution10/juniper-relay-helpers/pull/6))
- rename crate to include juniper
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).